### PR TITLE
[P1-001] Migrate project file from net8.0-windows to net8.0

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -1,16 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>FModel.ico</ApplicationIcon>
     <Version>4.4.4.0</Version>
     <AssemblyVersion>4.4.4.0</AssemblyVersion>
     <FileVersion>4.4.4.0</FileVersion>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PlatformTarget>x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
@@ -150,27 +148,48 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdonisUI" Version="1.17.1" />
-    <PackageReference Include="AdonisUI.ClassicTheme" Version="1.17.1" />
-    <PackageReference Include="Autoupdater.NET.Official" Version="1.9.2" />
-    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
-    <PackageReference Include="CSCore" Version="1.2.1.2" />
-    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
-    <PackageReference Include="EpicManifestParser" Version="2.4.1" />
-    <PackageReference Include="EpicManifestParser.ZlibngDotNetDecompressor" Version="1.0.1" />
-    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NVorbis" Version="0.10.5" />
-    <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="RestSharp" Version="113.0.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
-    <PackageReference Include="Svg.Skia" Version="3.2.1" />
-    <PackageReference Include="Twizzle.ImGui-Bundle.NET" Version="1.91.5.2" />
-    <PackageReference Include="VirtualizingWrapPanel" Version="2.3.2" />
+    <PackageReference Include="AdonisUI"
+                      Version="1.17.1" />
+    <PackageReference Include="AdonisUI.ClassicTheme"
+                      Version="1.17.1" />
+    <PackageReference Include="Autoupdater.NET.Official"
+                      Version="1.9.2" />
+    <PackageReference Include="AvalonEdit"
+                      Version="6.3.1.120" />
+    <PackageReference Include="CSCore"
+                      Version="1.2.1.2" />
+    <PackageReference Include="DiscordRichPresence"
+                      Version="1.6.1.70" />
+    <PackageReference Include="EpicManifestParser"
+                      Version="2.4.1" />
+    <PackageReference Include="EpicManifestParser.ZlibngDotNetDecompressor"
+                      Version="1.0.1" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams"
+                      Version="1.3.8" />
+    <PackageReference Include="Newtonsoft.Json"
+                      Version="13.0.4" />
+    <PackageReference Include="NVorbis"
+                      Version="0.10.5" />
+    <PackageReference Include="Ookii.Dialogs.Wpf"
+                      Version="5.0.1" />
+    <PackageReference Include="OpenTK"
+                      Version="4.9.4" />
+    <PackageReference Include="RestSharp"
+                      Version="113.0.0" />
+    <PackageReference Include="Serilog"
+                      Version="4.3.0" />
+    <PackageReference Include="Serilog.Sinks.File"
+                      Version="7.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp"
+                      Version="3.1.12" />
+    <PackageReference Include="SkiaSharp.HarfBuzz"
+                      Version="2.88.9" />
+    <PackageReference Include="Svg.Skia"
+                      Version="3.2.1" />
+    <PackageReference Include="Twizzle.ImGui-Bundle.NET"
+                      Version="1.91.5.2" />
+    <PackageReference Include="VirtualizingWrapPanel"
+                      Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Removes the Windows-specific TFM and WPF SDK flags from `FModel/FModel.csproj`, unblocking `dotnet restore` on Linux.

Closes #7

## Changes

| Property | Before | After |
|---|---|---|
| `TargetFramework` | `net8.0-windows` | `net8.0` |
| `OutputType` | `WinExe` | `Exe` |
| `UseWPF` | `true` | *(removed)* |
| `RuntimeIdentifier` | `win-x64` | *(removed — supply at publish time)* |

## Acceptance Criteria (from #7)

- [x] `dotnet restore FModel/FModel.csproj` succeeds on `linux-x64` without Windows TFM
- [x] `UseWPF` property is absent
- [x] `OutputType` is `Exe`
- [x] `RuntimeIdentifier` is not hardcoded to `win-x64`

## Notes

- `dotnet build` will still fail until Phase 1 package issues (#6, #8, #9, #11, #12, #13) are addressed — the remaining Windows-only packages (`AdonisUI`, `AvalonEdit`, `CSCore`, `Ookii.Dialogs.Wpf`, `VirtualizingWrapPanel`, `Autoupdater.NET.Official`) are out of scope for this PR.
- `PublishSingleFile` requires `-r <rid>` to be supplied at publish time. Publish profiles are tracked in Phase 5.
- `<Resource>` build action items will be migrated to `<AvaloniaResource>` in Phase 2 (#22).