### PR TITLE
[P1-003] Replace AvalonEdit with AvaloniaEdit

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -158,8 +158,8 @@
                       Version="11.3.12" />
     <PackageReference Include="Autoupdater.NET.Official"
                       Version="1.9.2" />
-    <PackageReference Include="AvalonEdit"
-                      Version="6.3.1.120" />
+    <PackageReference Include="AvaloniaEdit"
+                      Version="0.10.12" />
     <PackageReference Include="CSCore"
                       Version="1.2.1.2" />
     <PackageReference Include="DiscordRichPresence"


### PR DESCRIPTION
## Summary

Swaps the WPF-only `AvalonEdit` package for `AvaloniaEdit`, its API-compatible Avalonia port.

## Changes

| Action | Package | Version |
|---|---|---|
| ➖ Remove | `AvalonEdit` | 6.3.1.120 |
| ➕ Add | `AvaloniaEdit` | 0.10.12 |

## Notes

- `AvaloniaEdit` is maintained by the Avalonia team as a direct port of AvalonEdit — the public API (`TextEditor`, `TextDocument`, `IHighlightingDefinition`, `HighlightingManager`) is intentionally kept compatible to ease migration
- The existing `.xshd` syntax highlighting files (`Changelog.xshd`, `Cpp.xshd`, `Ini.xshd`, `Json.xshd`, `Verse.xshd`, `Xml.xshd`) are format-compatible with AvaloniaEdit and do not need changes at this stage
- Call-site migration (wiring `TextEditor` into Avalonia views) is tracked in issue #28

## Acceptance Criteria

- [x] `AvalonEdit` ref is absent
- [x] `AvaloniaEdit` 0.10.12 ref is present
- [x] `dotnet restore FModel/FModel.csproj` succeeds on linux-x64

Closes #12