### PR TITLE
[P1-004] Remove Ookii.Dialogs.Wpf

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -174,8 +174,6 @@
                       Version="13.0.4" />
     <PackageReference Include="NVorbis"
                       Version="0.10.5" />
-    <PackageReference Include="Ookii.Dialogs.Wpf"
-                      Version="5.0.1" />
     <PackageReference Include="OpenTK"
                       Version="4.9.4" />
     <PackageReference Include="RestSharp"


### PR DESCRIPTION
## Summary

Removes `Ookii.Dialogs.Wpf` from the package references. This package depends on `PresentationFramework` and cannot be restored on Linux.

## Changes

| Action | Package | Version |
|---|---|---|
| ➖ Remove | `Ookii.Dialogs.Wpf` | 5.0.1 |

## Notes

- No replacement is added here — the call-site migration to `Avalonia.StorageProvider.OpenFolderPickerAsync()` is a Phase 4 concern tracked in issue #48
- Affected call sites: `VistaFolderBrowserDialog` usage in `DirectorySelector.xaml.cs` and `SettingsView.xaml.cs`
- Removing the package reference will cause compile errors at those call sites, which is expected until #48 is resolved

## Acceptance Criteria

- [x] `Ookii.Dialogs.Wpf` ref is absent
- [x] `dotnet restore FModel/FModel.csproj` succeeds on linux-x64

Closes #11