### PR TITLE
[P1-005] Remove CSCore (Windows-only audio engine)

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -160,8 +160,6 @@
                       Version="1.9.2" />
     <PackageReference Include="AvaloniaEdit"
                       Version="0.10.12" />
-    <PackageReference Include="CSCore"
-                      Version="1.2.1.2" />
     <PackageReference Include="DiscordRichPresence"
                       Version="1.6.1.70" />
     <PackageReference Include="EpicManifestParser"


### PR DESCRIPTION
## Summary

Removes `CSCore` from the package references. This package uses Windows-exclusive audio APIs (`CoreAudioAPI`, `WASAPI`, `MediaFoundation`, `DirectSound`) and cannot be restored or run on Linux.

## Changes

| Action | Package | Version |
|---|---|---|
| ➖ Remove | `CSCore` | 1.2.1.2 |

## Notes

- No replacement is added here — the cross-platform audio engine replacement (`OpenTK.Audio.OpenAL` or equivalent) is tracked in issue #40 (P3-013)
- Affected call sites: `AudioPlayerViewModel.cs` and `CustomCodecFactory.cs`
- Removing the package reference will cause compile errors at those call sites, which is expected until #40 is resolved

## Acceptance Criteria

- [x] `CSCore` ref is absent
- [x] `dotnet restore FModel/FModel.csproj` succeeds on linux-x64

Closes #13