### PR TITLE
[P1-006] Remove VirtualizingWrapPanel (WPF-only panel)

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -188,8 +188,6 @@
                       Version="3.2.1" />
     <PackageReference Include="Twizzle.ImGui-Bundle.NET"
                       Version="1.91.5.2" />
-    <PackageReference Include="VirtualizingWrapPanel"
-                      Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Removes `VirtualizingWrapPanel` from the package references. This is a WPF-only third-party panel control with no Linux support.

## Changes

| Action | Package | Version |
|---|---|---|
| ➖ Remove | `VirtualizingWrapPanel` | 2.3.2 |

## Notes

- No replacement is added at this stage — Avalonia has a built-in `WrapPanel` that covers standard use cases, and virtualized panel options (e.g. `VirtualizingStackPanel` built into Avalonia) can be evaluated during the Phase 2 UI migration
- Call-site replacement is covered by the Phase 2 view migration work

## Acceptance Criteria

- [x] `VirtualizingWrapPanel` ref is absent
- [x] `dotnet restore FModel/FModel.csproj` succeeds on linux-x64

Closes #6