### PR TITLE
[P1-007] Remove Autoupdater.NET.Official (WPF-only auto-updater)

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -156,8 +156,6 @@
                       Version="11.3.12" />
     <PackageReference Include="Avalonia.Fonts.Inter"
                       Version="11.3.12" />
-    <PackageReference Include="Autoupdater.NET.Official"
-                      Version="1.9.2" />
     <PackageReference Include="AvaloniaEdit"
                       Version="0.10.12" />
     <PackageReference Include="DiscordRichPresence"


### PR DESCRIPTION
## Summary

Removes `Autoupdater.NET.Official` from the package references. This package requires WPF for its built-in download progress dialog and cannot be used on Linux.

## Changes

| Action | Package | Version |
|---|---|---|
| ➖ Remove | `Autoupdater.NET.Official` | 1.9.2 |

## Notes

- No replacement is added at this stage — the cross-platform auto-update reimplementation is tracked in issue #51 (P4-005)
- Affected call sites: `AutoUpdater.Start()`, `ParseUpdateInfoEvent`, `CheckForUpdateEvent` in `FModelApiEndpoint.cs`; `AutoUpdater.DownloadUpdate()` in `GitHubResponse.cs`
- Removing the package reference will cause compile errors at those call sites, which is expected until #51 is resolved

## Acceptance Criteria

- [x] `Autoupdater.NET.Official` ref is absent
- [x] `dotnet restore FModel/FModel.csproj` succeeds on linux-x64

Closes #9