### PR TITLE
phase1: point CUE4Parse submodule at r6e/CUE4Parse-Linux (#10)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CUE4Parse"]
 	path = CUE4Parse
-	url = https://github.com/FabianFG/CUE4Parse
+        url = https://github.com/r6e/CUE4Parse-Linux


### PR DESCRIPTION
## Summary

Closes #10.

Updates the CUE4Parse git submodule to point at the `r6e/CUE4Parse-Linux` fork instead of upstream `FabianFG/CUE4Parse`, pinned to commit `06fbf1ac` ("Add Linux support").

## What changed in the submodule

The `r6e/CUE4Parse-Linux` fork adds Linux-compatible native libraries alongside the existing Windows DLLs:

- **`libdetex.so`** — built from [hglm/detex](https://github.com/hglm/detex) with `-DDETEX_SHARED_EXPORTS`, exports `detexDecompressTextureLinear`
- **`libtegra_swizzle_x64.so`** — built from [ScanMountGoat/tegra_swizzle](https://github.com/ScanMountGoat/tegra_swizzle) v0.4.0 with `--features ffi`, exports `deswizzle_block_linear`, `swizzled_surface_size`, `block_height_mip0`, `mip_block_height`

And updates the loading code to be OS-aware:

- **`DetexHelper.cs`** — `MANIFEST_URL` / `DLL_NAME` replaced with `RuntimeInformation.IsOSPlatform(OSPlatform.Linux)`-based properties that select `libdetex.so` on Linux
- **`PlatformDeswizzlers.cs`** — adds `NativeLibrary.SetDllImportResolver` in the static constructor to redirect the `[DllImport("tegra_swizzle_x64")]` calls to `libtegra_swizzle_x64.so` on Linux; `PrepareDllFile()` made OS-aware to extract the correct embedded resource