### PR TITLE
feat(#15): migrate MainWindow.xaml + MainWindow.xaml.cs to Avalonia Window

### DIFF
--- a/FModel/App.xaml
+++ b/FModel/App.xaml
@@ -21,6 +21,17 @@
             <Color x:Key="ErrorColor">#C22B2B</Color>
             <SolidColorBrush x:Key="ErrorColorBrush"
                              Color="{StaticResource ErrorColor}" />
+            <!--
+                WPF SystemColors aliases (M1 fix). These are stopgap values
+                matching AdonisUI dark-theme equivalents; they will be replaced
+                when the full resource-dictionary migration is done.
+            -->
+            <SolidColorBrush x:Key="SystemColors.ControlTextBrushKey"
+                             Color="#E8E8E8" />
+            <SolidColorBrush x:Key="SystemColors.ControlBrushKey"
+                             Color="#3C3C3C" />
+            <SolidColorBrush x:Key="SystemColors.AppWorkspaceBrushKey"
+                             Color="#1E1E1E" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/FModel/App.xaml.cs
+++ b/FModel/App.xaml.cs
@@ -44,7 +44,7 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // TODO(#15): desktop.MainWindow = new Views.MainWindow();
+            desktop.MainWindow = new MainWindow();
             desktop.Exit += AppExit;
         }
 

--- a/FModel/Helper.cs
+++ b/FModel/Helper.cs
@@ -40,7 +40,8 @@ public static class Helper
         else
         {
             var w = GetOpenedWindow<T>(windowName);
-            if (windowName == "Search For Packages") w.WindowState = WindowState.Normal;
+            if (windowName == "Search For Packages")
+                w.WindowState = WindowState.Normal;
             w.Focus();
         }
     }
@@ -59,7 +60,8 @@ public static class Helper
 
     public static void CloseWindow<T>(string windowName) where T : Window
     {
-        if (!IsWindowOpen<T>(windowName)) return;
+        if (!IsWindowOpen<T>(windowName))
+            return;
         GetOpenedWindow<T>(windowName).Close();
     }
 

--- a/FModel/Helper.cs
+++ b/FModel/Helper.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Windows;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 
 namespace FModel;
 
@@ -52,7 +54,6 @@ public static class Helper
 
         var ret = (T) GetOpenedWindow<T>(windowName);
         ret.Focus();
-        ret.Activate();
         return ret;
     }
 
@@ -62,16 +63,23 @@ public static class Helper
         GetOpenedWindow<T>(windowName).Close();
     }
 
+    private static IEnumerable<Window> GetAllWindows()
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            return desktop.Windows;
+        return Enumerable.Empty<Window>();
+    }
+
     private static bool IsWindowOpen<T>(string name = "") where T : Window
     {
         return string.IsNullOrEmpty(name)
-            ? Application.Current.Windows.OfType<T>().Any()
-            : Application.Current.Windows.OfType<T>().Any(w => w.Title.Equals(name));
+            ? GetAllWindows().OfType<T>().Any()
+            : GetAllWindows().OfType<T>().Any(w => w.Title?.Equals(name) == true);
     }
 
     private static Window GetOpenedWindow<T>(string name) where T : Window
     {
-        return Application.Current.Windows.OfType<T>().FirstOrDefault(w => w.Title.Equals(name));
+        return GetAllWindows().OfType<T>().FirstOrDefault(w => w.Title?.Equals(name) == true);
     }
 
     public static bool IsNaN(double value)

--- a/FModel/MainWindow.xaml
+++ b/FModel/MainWindow.xaml
@@ -11,7 +11,8 @@
         Closing="OnClosing"
         Loaded="OnLoaded"
         KeyDown="OnWindowKeyDown"
-        Width="1400" Height="900">
+        Width="1400"
+        Height="900">
     <!--
         Title is set in code-behind (OnLoaded / property change) to replicate the
         DataTrigger-based title logic that was in the WPF AdonisWindow style.
@@ -21,8 +22,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="8" />
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0">
@@ -33,144 +34,226 @@
 
             <Menu Grid.Column="0">
                 <MenuItem Header="Directory">
-                    <MenuItem Header="Selector" Command="{Binding MenuCommand}" CommandParameter="Directory_Selector">
+                    <MenuItem Header="Selector"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Directory_Selector">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource DirectoryIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource DirectoryIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="AES" Command="{Binding MenuCommand}" CommandParameter="Directory_AES" IsEnabled="{Binding Status.IsReady}">
+                    <MenuItem Header="AES"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Directory_AES"
+                              IsEnabled="{Binding Status.IsReady}">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource KeyIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource KeyIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Backup" Command="{Binding MenuCommand}" CommandParameter="Directory_Backup" IsEnabled="{Binding Status.IsReady}">
+                    <MenuItem Header="Backup"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Directory_Backup"
+                              IsEnabled="{Binding Status.IsReady}">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource BackupIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource BackupIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Archives Info" Command="{Binding MenuCommand}" CommandParameter="Directory_ArchivesInfo" IsEnabled="{Binding Status.IsReady}">
+                    <MenuItem Header="Archives Info"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Directory_ArchivesInfo"
+                              IsEnabled="{Binding Status.IsReady}">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource InfoIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource InfoIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
                 </MenuItem>
                 <MenuItem Header="Packages">
-                    <MenuItem Header="Search" IsEnabled="{Binding Status.IsReady}" InputGestureText="Ctrl+Shift+F" Click="OnSearchViewClick">
+                    <MenuItem Header="Search"
+                              IsEnabled="{Binding Status.IsReady}"
+                              InputGestureText="Ctrl+Shift+F"
+                              Click="OnSearchViewClick">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource SearchIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource SearchIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="References" IsEnabled="{Binding Status.IsReady}" InputGestureText="Ctrl+Shift+R" Click="OnRefViewClick">
+                    <MenuItem Header="References"
+                              IsEnabled="{Binding Status.IsReady}"
+                              InputGestureText="Ctrl+Shift+R"
+                              Click="OnRefViewClick">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource SearchIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource SearchIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Favorite Directories" ItemsSource="{Binding CustomDirectories.Directories}" IsEnabled="{Binding Status.IsReady}">
+                    <MenuItem Header="Favorite Directories"
+                              ItemsSource="{Binding CustomDirectories.Directories}"
+                              IsEnabled="{Binding Status.IsReady}">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource DirectoriesIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                          Data="{StaticResource DirectoriesIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
                 </MenuItem>
                 <MenuItem Header="Views">
-                    <MenuItem Header="3D Viewer" Command="{Binding MenuCommand}" CommandParameter="Views_3dViewer">
+                    <MenuItem Header="3D Viewer"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Views_3dViewer">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource MeshIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource MeshIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Audio Player" Command="{Binding MenuCommand}" CommandParameter="Views_AudioPlayer">
+                    <MenuItem Header="Audio Player"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Views_AudioPlayer">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource AudioIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource AudioIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Image Merger" Command="{Binding MenuCommand}" CommandParameter="Views_ImageMerger">
+                    <MenuItem Header="Image Merger"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Views_ImageMerger">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource ImageMergerIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource ImageMergerIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
                 </MenuItem>
-                <MenuItem Header="Settings" Command="{Binding MenuCommand}" CommandParameter="Settings" />
-                <MenuItem Header="Help" >
-                    <MenuItem Header="Donate" Command="{Binding MenuCommand}" CommandParameter="Help_Donate">
+                <MenuItem Header="Settings"
+                          Command="{Binding MenuCommand}"
+                          CommandParameter="Settings" />
+                <MenuItem Header="Help">
+                    <MenuItem Header="Donate"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Help_Donate">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource GiftIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource GiftIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Releases" Command="{Binding MenuCommand}" CommandParameter="Help_Releases">
+                    <MenuItem Header="Releases"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Help_Releases">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource GitHubIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource GitHubIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Bugs Report" Command="{Binding MenuCommand}" CommandParameter="Help_BugsReport">
+                    <MenuItem Header="Bugs Report"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Help_BugsReport">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource BugIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource BugIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Discord Server" Command="{Binding MenuCommand}" CommandParameter="Help_Discord">
+                    <MenuItem Header="Discord Server"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Help_Discord">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource DiscordIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource DiscordIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="About FModel" Command="{Binding MenuCommand}" CommandParameter="Help_About">
+                    <MenuItem Header="About FModel"
+                              Command="{Binding MenuCommand}"
+                              CommandParameter="Help_About">
                         <MenuItem.Icon>
-                            <Viewbox Width="16" Height="16">
-                                <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource InfoIcon}" />
+                            <Viewbox Width="16"
+                                     Height="16">
+                                <Canvas Width="24"
+                                        Height="24">
+                                    <Path Fill="{DynamicResource AccentColorBrush}"
+                                          Data="{StaticResource InfoIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -184,24 +267,34 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Text="Preview New Explorer System" VerticalAlignment="Center" />
-                <CheckBox Grid.Column="1" Margin="5 2 5 0" Unchecked="FeaturePreviewOnUnchecked" KeyboardNavigation.TabNavigation="None" KeyboardNavigation.ControlTabNavigation="None"
-                          IsChecked="{Binding FeaturePreviewNewAssetExplorer, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}"
-                          />
+                <TextBlock Grid.Column="0"
+                           Text="Preview New Explorer System"
+                           VerticalAlignment="Center" />
+                <CheckBox Grid.Column="1"
+                          Margin="5 2 5 0"
+                          Unchecked="FeaturePreviewOnUnchecked"
+                          KeyboardNavigation.TabNavigation="None"
+                          IsChecked="{Binding FeaturePreviewNewAssetExplorer, Source={x:Static settings:UserSettings.Default}, Mode=TwoWay}" />
             </Grid>
         </Grid>
 
-        <Grid x:Name="RootGrid" Grid.Row="2">
+        <Grid x:Name="RootGrid"
+              Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" MinWidth="400" />
+                <ColumnDefinition Width="Auto"
+                                  MinWidth="400" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
             <GroupBox Grid.Column="0"
-                      Padding="0" Background="Transparent">
-                <TabControl x:Name="LeftTabControl" SelectionChanged="OnTabItemChange" SelectedIndex="{Binding SelectedLeftTabIndex, Mode=TwoWay}">
-                    <TabItem Style="{StaticResource TabItemFillSpace}" Header="Archives">
+                      Padding="0"
+                      Background="Transparent">
+                <TabControl x:Name="LeftTabControl"
+                            SelectionChanged="OnTabItemChange"
+                            SelectedIndex="{Binding SelectedLeftTabIndex, Mode=TwoWay}">
+                    <TabItem Style="{StaticResource TabItemFillSpace}"
+                             Header="Archives">
                         <DockPanel>
                             <Grid DockPanel.Dock="Top">
                                 <Grid.RowDefinitions>
@@ -215,8 +308,14 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
 
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Loading Mode" VerticalAlignment="Center" />
-                                <ComboBox Grid.Row="0" Grid.Column="2" ItemsSource="{Binding LoadingModes.Modes}" IsEnabled="{Binding Status.IsReady}"
+                                <TextBlock Grid.Row="0"
+                                           Grid.Column="0"
+                                           Text="Loading Mode"
+                                           VerticalAlignment="Center" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="2"
+                                          ItemsSource="{Binding LoadingModes.Modes}"
+                                          IsEnabled="{Binding Status.IsReady}"
                                           SelectedItem="{Binding LoadingMode, Source={x:Static settings:UserSettings.Default}, Mode=TwoWay}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
@@ -224,8 +323,12 @@
                                         </DataTemplate>
                                     </ComboBox.ItemTemplate>
                                 </ComboBox>
-                                <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Content="Load"
-                                        Command="{Binding LoadingModes.LoadCommand}" IsEnabled="{Binding Status.IsReady}"
+                                <Button Grid.Row="2"
+                                        Grid.Column="0"
+                                        Grid.ColumnSpan="3"
+                                        Content="Load"
+                                        Command="{Binding LoadingModes.LoadCommand}"
+                                        IsEnabled="{Binding Status.IsReady}"
                                         CommandParameter="{Binding SelectedItems, ElementName=DirectoryFilesListBox}" />
                             </Grid>
                             <Grid DockPanel.Dock="Top">
@@ -236,10 +339,19 @@
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
-                                <Separator Grid.Row="0" Style="{StaticResource CustomSeparator}" Tag="GAME ARCHIVES" />
-                                <ListBox Grid.Row="1" x:Name="DirectoryFilesListBox" Style="{StaticResource DirectoryFilesListBox}" DoubleTapped="OnMouseDoubleClick" />
-                                <Separator Grid.Row="2" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
-                                <StackPanel Grid.Row="3" Orientation="Vertical" Margin="0 0 0 5">
+                                <Separator Grid.Row="0"
+                                           Style="{StaticResource CustomSeparator}"
+                                           Tag="GAME ARCHIVES" />
+                                <ListBox Grid.Row="1"
+                                         x:Name="DirectoryFilesListBox"
+                                         Style="{StaticResource DirectoryFilesListBox}"
+                                         DoubleTapped="OnMouseDoubleClick" />
+                                <Separator Grid.Row="2"
+                                           Style="{StaticResource CustomSeparator}"
+                                           Tag="INFORMATION" />
+                                <StackPanel Grid.Row="3"
+                                            Orientation="Vertical"
+                                            Margin="0 0 0 5">
                                     <Grid HorizontalAlignment="Stretch">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
@@ -252,14 +364,46 @@
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
 
-                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding SelectedItem.MountPoint, ElementName=DirectoryFilesListBox, FallbackValue='/', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="Mount Point" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding SelectedItem.FileCount, ElementName=DirectoryFilesListBox, FallbackValue='0', StringFormat={}{0} Files}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="File Count" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="{Binding SelectedItem.IsEncrypted, ElementName=DirectoryFilesListBox, FallbackValue='False'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="2" Grid.Column="1" Text="Is Encrypted" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="{Binding SelectedItem.Guid, ElementName=DirectoryFilesListBox, FallbackValue='00000000000000000000000000000000'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="3" Grid.Column="1" Text="Global Unique Identifier" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="0"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.MountPoint, ElementName=DirectoryFilesListBox, FallbackValue='/', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="0"
+                                                   Grid.Column="1"
+                                                   Text="Mount Point"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="1"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.FileCount, ElementName=DirectoryFilesListBox, FallbackValue='0', StringFormat={}{0} Files}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="1"
+                                                   Grid.Column="1"
+                                                   Text="File Count"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="2"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.IsEncrypted, ElementName=DirectoryFilesListBox, FallbackValue='False'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="2"
+                                                   Grid.Column="1"
+                                                   Text="Is Encrypted"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="3"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Guid, ElementName=DirectoryFilesListBox, FallbackValue='00000000000000000000000000000000'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="3"
+                                                   Grid.Column="1"
+                                                   Text="Global Unique Identifier"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
                                     </Grid>
                                 </StackPanel>
                             </Grid>
@@ -283,47 +427,80 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                    <Image Source="/FModel;component/Resources/label.png"
-                                           Width="16" Height="16" HorizontalAlignment="Center" Margin="0 0 3.5 0" />
-                                    <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
+                                <StackPanel Grid.Column="0"
+                                            Orientation="Horizontal">
+                                    <Image Source="avares://FModel/Resources/label.png"
+                                           Width="16"
+                                           Height="16"
+                                           HorizontalAlignment="Center"
+                                           Margin="0 0 3.5 0" />
+                                    <TextBlock HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis">
                                         <TextBlock.Text>
                                             <MultiBinding StringFormat="{}'{0}' has {1} folders and {2} packages">
-                                                <Binding Path="SelectedItem.Header" ElementName="AssetsFolderName" FallbackValue="None" />
-                                                <Binding Path="SelectedItem.FoldersView.Count" ElementName="AssetsFolderName" FallbackValue="0" />
-                                                <Binding Path="SelectedItem.AssetsList.Assets.Count" ElementName="AssetsFolderName" FallbackValue="0" />
+                                                <Binding Path="SelectedItem.Header"
+                                                         ElementName="AssetsFolderName"
+                                                         FallbackValue="None" />
+                                                <Binding Path="SelectedItem.FoldersView.Count"
+                                                         ElementName="AssetsFolderName"
+                                                         FallbackValue="0" />
+                                                <Binding Path="SelectedItem.AssetsList.Assets.Count"
+                                                         ElementName="AssetsFolderName"
+                                                         FallbackValue="0" />
                                             </MultiBinding>
                                         </TextBlock.Text>
                                     </TextBlock>
                                 </StackPanel>
-                                <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                                    <Button  ToolTip="Bring Selected Folder To View" Padding="4"
-                                            Command="{Binding MenuCommand}" CommandParameter="{Binding SelectedItem, ElementName=AssetsFolderName}">
-                                        <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                                            <Canvas Width="24" Height="24">
-                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource LocateMeIcon}" />
+                                <StackPanel Grid.Column="2"
+                                            Orientation="Horizontal"
+                                            HorizontalAlignment="Right">
+                                    <Button ToolTip.Tip="Bring Selected Folder To View"
+                                            Padding="4"
+                                            Command="{Binding MenuCommand}"
+                                            CommandParameter="{Binding SelectedItem, ElementName=AssetsFolderName}">
+                                        <Viewbox Width="16"
+                                                 Height="16"
+                                                 HorizontalAlignment="Center">
+                                            <Canvas Width="24"
+                                                    Height="24">
+                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                                      Data="{StaticResource LocateMeIcon}" />
                                             </Canvas>
                                         </Viewbox>
                                     </Button>
-                                    <!-- <Button  ToolTip="Expand All (not appropriate for huge amount of folders)" Padding="4" -->
-                                    <!--         Command="{Binding MenuCommand}" CommandParameter="ToolBox_Expand_All"> -->
-                                    <!--     <Viewbox Width="16" Height="16" HorizontalAlignment="Center"> -->
+                                    <!-- <Button  ToolTip="Expand All (not appropriate for huge
+                                    amount of folders)" Padding="4" -->
+                                    <!--         Command="{Binding MenuCommand}"
+                                    CommandParameter="ToolBox_Expand_All"> -->
+                                    <!--     <Viewbox Width="16" Height="16"
+                                    HorizontalAlignment="Center"> -->
                                     <!--         <Canvas Width="24" Height="24"> -->
-                                    <!--             <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource UnfoldIcon}" /> -->
+                                    <!--             <Path Fill="{DynamicResource
+                                    SystemColors.ControlTextBrushKey}" Data="{StaticResource
+                                    UnfoldIcon}" /> -->
                                     <!--         </Canvas> -->
                                     <!--     </Viewbox> -->
                                     <!-- </Button> -->
-                                    <Button  ToolTip="Collapse All" Padding="4"
-                                            Command="{Binding MenuCommand}" CommandParameter="ToolBox_Collapse_All">
-                                        <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                                            <Canvas Width="24" Height="24">
-                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource FoldIcon}"/>
+                                    <Button ToolTip.Tip="Collapse All"
+                                            Padding="4"
+                                            Command="{Binding MenuCommand}"
+                                            CommandParameter="ToolBox_Collapse_All">
+                                        <Viewbox Width="16"
+                                                 Height="16"
+                                                 HorizontalAlignment="Center">
+                                            <Canvas Width="24"
+                                                    Height="24">
+                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                                      Data="{StaticResource FoldIcon}" />
                                             </Canvas>
                                         </Viewbox>
                                     </Button>
                                 </StackPanel>
                             </Grid>
-                            <Separator Grid.Row="1" Style="{StaticResource CustomSeparator}" Margin="0" />
+                            <Separator Grid.Row="1"
+                                       Style="{StaticResource CustomSeparator}"
+                                       Margin="0" />
                             <TreeView Grid.Row="2"
                                       x:Name="AssetsFolderName"
                                       Style="{StaticResource AssetsFolderTreeView}"
@@ -331,8 +508,12 @@
                                       KeyDown="OnFoldersPreviewKeyDown"
                                       DoubleTapped="OnAssetsTreeMouseDoubleClick">
                             </TreeView>
-                            <Separator Grid.Row="3" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
-                            <StackPanel Grid.Row="4" Orientation="Vertical" Margin="0 0 0 5">
+                            <Separator Grid.Row="3"
+                                       Style="{StaticResource CustomSeparator}"
+                                       Tag="INFORMATION" />
+                            <StackPanel Grid.Row="4"
+                                        Orientation="Vertical"
+                                        Margin="0 0 0 5">
                                 <Grid HorizontalAlignment="Stretch">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
@@ -346,16 +527,56 @@
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
 
-                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding SelectedItem.AssetsList.Assets.Count, ElementName=AssetsFolderName, FallbackValue=0}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Packages Count" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding SelectedItem.FoldersView.Count, ElementName=AssetsFolderName, FallbackValue=0}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Folders Count" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="{Binding SelectedItem.Archive, ElementName=AssetsFolderName, FallbackValue='None'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Included In Archive" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{Binding SelectedItem.MountPoint, ElementName=AssetsFolderName, FallbackValue='/', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Archive Mount Point" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{Binding SelectedItem.Version, ElementName=AssetsFolderName, FallbackValue='VER_UE4_LATEST', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="Archive Version" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               Text="{Binding SelectedItem.AssetsList.Assets.Count, ElementName=AssetsFolderName, FallbackValue=0}"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Left" />
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="1"
+                                               Text="Packages Count"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               Text="{Binding SelectedItem.FoldersView.Count, ElementName=AssetsFolderName, FallbackValue=0}"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Left" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="1"
+                                               Text="Folders Count"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               Text="{Binding SelectedItem.Archive, ElementName=AssetsFolderName, FallbackValue='None'}"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Left" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="1"
+                                               Text="Included In Archive"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               Text="{Binding SelectedItem.MountPoint, ElementName=AssetsFolderName, FallbackValue='/', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Left" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="1"
+                                               Text="Archive Mount Point"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Row="4"
+                                               Grid.Column="0"
+                                               Text="{Binding SelectedItem.Version, ElementName=AssetsFolderName, FallbackValue='VER_UE4_LATEST', Converter={x:Static converters:TrimRightToLeftConverter.Instance}, ConverterParameter=275}"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Left" />
+                                    <TextBlock Grid.Row="4"
+                                               Grid.Column="1"
+                                               Text="Archive Version"
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
                                 </Grid>
                             </StackPanel>
                         </Grid>
@@ -365,7 +586,8 @@
                              HeaderStringFormat="{}{0} Packages">
                         <DockPanel>
 
-                            <inputs:SearchTextBox DockPanel.Dock="Top" x:Name="AssetsSearchTextBox"
+                            <inputs:SearchTextBox DockPanel.Dock="Top"
+                                                  x:Name="AssetsSearchTextBox"
                                                   Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay}"
                                                   ClearButtonClick="OnClearFilterClick" />
 
@@ -377,17 +599,24 @@
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
-                                <controls:Breadcrumb Grid.Row="0" HorizontalAlignment="Left" Margin="0 5 0 5"
+                                <controls:Breadcrumb Grid.Row="0"
+                                                     HorizontalAlignment="Left"
+                                                     Margin="0 5 0 5"
                                                      MaxWidth="{Binding ActualWidth, ElementName=AssetsSearchTextBox}"
-                                                     DataContext="{Binding SelectedItem.PathAtThisPoint, ElementName=AssetsFolderName, FallbackValue='No/Directory/Detected/In/Folder'}"/>
+                                                     DataContext="{Binding SelectedItem.PathAtThisPoint, ElementName=AssetsFolderName, FallbackValue='No/Directory/Detected/In/Folder'}" />
 
-                                <ListBox Grid.Row="1" x:Name="AssetsListName"
+                                <ListBox Grid.Row="1"
+                                         x:Name="AssetsListName"
                                          Style="{StaticResource AssetsListBox}"
                                          DoubleTapped="OnAssetsListMouseDoubleClick"
                                          KeyDown="OnPreviewKeyDown" />
 
-                                <Separator Grid.Row="2" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
-                                <StackPanel Grid.Row="3" Orientation="Vertical" Margin="0 0 0 5">
+                                <Separator Grid.Row="2"
+                                           Style="{StaticResource CustomSeparator}"
+                                           Tag="INFORMATION" />
+                                <StackPanel Grid.Row="3"
+                                            Orientation="Vertical"
+                                            Margin="0 0 0 5">
                                     <Grid HorizontalAlignment="Stretch">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
@@ -401,16 +630,56 @@
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
 
-                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding SelectedItem.Asset.Offset, ElementName=AssetsListName, FallbackValue=0, StringFormat='{}0x{0:X}'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="Offset" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding SelectedItem.Asset.Size, ElementName=AssetsListName, FallbackValue=0, Converter={x:Static converters:SizeToStringConverter.Instance}}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="Size" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="{Binding SelectedItem.Asset.CompressionMethod, ElementName=AssetsListName, FallbackValue='Unknown'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="2" Grid.Column="1" Text="Compression Method" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="{Binding SelectedItem.Asset.IsEncrypted, ElementName=AssetsListName, FallbackValue='False'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="3" Grid.Column="1" Text="Is Encrypted" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="{Binding SelectedItem.Asset.Vfs.Name, ElementName=AssetsListName, FallbackValue='None'}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                                        <TextBlock Grid.Row="4" Grid.Column="1" Text="Included In Archive" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="0"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Asset.Offset, ElementName=AssetsListName, FallbackValue=0, StringFormat='{}0x{0:X}'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="0"
+                                                   Grid.Column="1"
+                                                   Text="Offset"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="1"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Asset.Size, ElementName=AssetsListName, FallbackValue=0, Converter={x:Static converters:SizeToStringConverter.Instance}}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="1"
+                                                   Grid.Column="1"
+                                                   Text="Size"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="2"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Asset.CompressionMethod, ElementName=AssetsListName, FallbackValue='Unknown'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="2"
+                                                   Grid.Column="1"
+                                                   Text="Compression Method"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="3"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Asset.IsEncrypted, ElementName=AssetsListName, FallbackValue='False'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="3"
+                                                   Grid.Column="1"
+                                                   Text="Is Encrypted"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Row="4"
+                                                   Grid.Column="0"
+                                                   Text="{Binding SelectedItem.Asset.Vfs.Name, ElementName=AssetsListName, FallbackValue='None'}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Row="4"
+                                                   Grid.Column="1"
+                                                   Text="Included In Archive"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right" />
                                     </Grid>
                                 </StackPanel>
                             </Grid>
@@ -419,12 +688,17 @@
                 </TabControl>
             </GroupBox>
 
-            <GridSplitter Grid.Column="1" ResizeDirection="Columns" Width="4" VerticalAlignment="Stretch"
-                          ResizeBehavior="PreviousAndNext" DoubleTapped="OnGridSplitterDoubleClick"
+            <GridSplitter Grid.Column="1"
+                          ResizeDirection="Columns"
+                          Width="4"
+                          VerticalAlignment="Stretch"
+                          ResizeBehavior="PreviousAndNext"
+                          DoubleTapped="OnGridSplitterDoubleClick"
                           Background="{DynamicResource SystemColors.ControlBrushKey}" />
 
             <GroupBox Grid.Column="2"
-                      Padding="0" Background="Transparent">
+                      Padding="0"
+                      Background="Transparent">
                 <Grid Margin="0 0 3 0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
@@ -432,8 +706,8 @@
                     </Grid.RowDefinitions>
 
                     <Grid Grid.Row="0">
-                        <Border BorderThickness="1" Padding="10"
-                                
+                        <Border BorderThickness="1"
+                                Padding="10"
                                 Background="{DynamicResource SystemColors.AppWorkspaceBrushKey}"
                                 IsVisible="{Binding IsAssetsExplorerVisible}">
                             <Grid>
@@ -447,23 +721,28 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="5" />
-                                        <ColumnDefinition Width="Auto" MinWidth="150" />
+                                        <ColumnDefinition Width="Auto"
+                                                          MinWidth="150" />
                                     </Grid.ColumnDefinitions>
 
-                                    <inputs:SearchTextBox x:Name="AssetsExplorerSearch" Grid.Column="0"
+                                    <inputs:SearchTextBox x:Name="AssetsExplorerSearch"
+                                                          Grid.Column="0"
                                                           Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay}"
                                                           ClearButtonClick="OnClearFilterClick" />
 
-                                    <ComboBox x:Name="CategoriesSelector" Grid.Column="2"
+                                    <ComboBox x:Name="CategoriesSelector"
+                                              Grid.Column="2"
                                               ItemsSource="{Binding Categories}"
                                               SelectedItem="{Binding SelectedItem.SelectedCategory, ElementName=AssetsFolderName, Mode=TwoWay}" />
                                 </Grid>
 
-                                <controls:Breadcrumb Grid.Row="1" Margin="0 5 0 0"
+                                <controls:Breadcrumb Grid.Row="1"
+                                                     Margin="0 5 0 0"
                                                      HorizontalAlignment="Left"
                                                      DataContext="{Binding SelectedItem.PathAtThisPoint, ElementName=AssetsFolderName}" />
 
-                                <ListBox x:Name="AssetsExplorer" Grid.Row="2"
+                                <ListBox x:Name="AssetsExplorer"
+                                         Grid.Row="2"
                                          ItemsSource="{Binding SelectedItem.CombinedEntries, ElementName=AssetsFolderName, IsAsync=True}"
                                          Style="{StaticResource TiledExplorer}"
                                          Background="{DynamicResource SystemColors.AppWorkspaceBrushKey}"
@@ -487,12 +766,14 @@
                         <!-- Opacity fade replaces WPF Storyboard EventTriggers on MouseEnter/Leave -->
                         <Border.Transitions>
                             <Transitions>
-                                <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
+                                <DoubleTransition Property="Opacity"
+                                                  Duration="0:0:0.2" />
                             </Transitions>
                         </Border.Transitions>
                         <Border.Styles>
                             <Style Selector="Border:pointerover">
-                                <Setter Property="Opacity" Value="1" />
+                                <Setter Property="Opacity"
+                                        Value="1" />
                             </Style>
                         </Border.Styles>
                         <StackPanel Orientation="Horizontal"
@@ -511,10 +792,13 @@
                                           ToolTip.Tip="Preview Textures (OFF)"
                                           IsChecked="{Binding PreviewTexturesAssetExplorer, Source={x:Static settings:UserSettings.Default}, Mode=TwoWay}">
                                 <ToggleButton.Styles>
-                                    <!-- WPF IsChecked=True trigger: purple background and updated tooltip -->
+                                    <!-- WPF IsChecked=True trigger: purple background and updated
+                                    tooltip -->
                                     <Style Selector="ToggleButton:checked">
-                                        <Setter Property="Background" Value="MediumPurple" />
-                                        <Setter Property="ToolTip.Tip" Value="Preview Textures (ON)" />
+                                        <Setter Property="Background"
+                                                Value="MediumPurple" />
+                                        <Setter Property="ToolTip.Tip"
+                                                Value="Preview Textures (ON)" />
                                     </Style>
                                 </ToggleButton.Styles>
                                 <Viewbox Width="16"
@@ -529,7 +813,9 @@
                         </StackPanel>
                     </Border>
 
-                    <Expander Grid.Row="1" Margin="0 5 0 5" ExpandDirection="Down"
+                    <Expander Grid.Row="1"
+                              Margin="0 5 0 5"
+                              ExpandDirection="Down"
                               IsExpanded="{Binding IsLoggerExpanded, Source={x:Static settings:UserSettings.Default}}">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -538,21 +824,41 @@
                                 <ColumnDefinition Width="24" />
                             </Grid.ColumnDefinitions>
 
-                            <controls:CustomRichTextBox Grid.Column="0" Grid.ColumnSpan="3" x:Name="LogRtbName" Style="{StaticResource CustomRichTextBox}" />
-                            <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Bottom" Margin="-5 -5 5 5">
-                                <Button  ToolTip="Open Output Folder" Padding="0,4,0,4"
-                                        Command="{Binding MenuCommand}" CommandParameter="ToolBox_Open_Output_Directory" Focusable="False">
-                                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                                        <Canvas Width="24" Height="24">
-                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource FolderIcon}" />
+                            <controls:CustomRichTextBox Grid.Column="0"
+                                                        Grid.ColumnSpan="3"
+                                                        x:Name="LogRtbName"
+                                                        Style="{StaticResource CustomRichTextBox}" />
+                            <StackPanel Grid.Column="2"
+                                        Orientation="Vertical"
+                                        VerticalAlignment="Bottom"
+                                        Margin="-5 -5 5 5">
+                                <Button ToolTip.Tip="Open Output Folder"
+                                        Padding="0,4,0,4"
+                                        Command="{Binding MenuCommand}"
+                                        CommandParameter="ToolBox_Open_Output_Directory"
+                                        Focusable="False">
+                                    <Viewbox Width="16"
+                                             Height="16"
+                                             HorizontalAlignment="Center">
+                                        <Canvas Width="24"
+                                                Height="24">
+                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                                  Data="{StaticResource FolderIcon}" />
                                         </Canvas>
                                     </Viewbox>
                                 </Button>
-                                <Button  ToolTip="Clear Logs" Padding="0,4,0,4"
-                                        Command="{Binding MenuCommand}" CommandParameter="ToolBox_Clear_Logs" Focusable="False">
-                                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                                        <Canvas Width="24" Height="24">
-                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource TrashIcon}"/>
+                                <Button ToolTip.Tip="Clear Logs"
+                                        Padding="0,4,0,4"
+                                        Command="{Binding MenuCommand}"
+                                        CommandParameter="ToolBox_Clear_Logs"
+                                        Focusable="False">
+                                    <Viewbox Width="16"
+                                             Height="16"
+                                             HorizontalAlignment="Center">
+                                        <Canvas Width="24"
+                                                Height="24">
+                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}"
+                                                  Data="{StaticResource TrashIcon}" />
                                         </Canvas>
                                     </Viewbox>
                                 </Button>
@@ -570,22 +876,30 @@
             flash animations (StatusChangeAttempted, OperationCancelled) are
             also handled in code-behind via DispatcherTimer.
         -->
-        <Border x:Name="StatusBarBorder" Grid.Row="3" MinHeight="28" MaxHeight="28"
+        <Border x:Name="StatusBarBorder"
+                Grid.Row="3"
+                MinHeight="28"
+                MaxHeight="28"
                 Padding="5,0">
             <DockPanel LastChildFill="False">
                 <TextBlock x:Name="StatusLabel"
                            DockPanel.Dock="Left"
-                           VerticalAlignment="Center"
-                           Text="{Binding Status.Label}" />
+                           VerticalAlignment="Center" />
 
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Viewbox Width="16" Height="16" Margin="0,0,10,0">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource StatusBarIcon}" />
+                <StackPanel DockPanel.Dock="Right"
+                            Orientation="Horizontal">
+                    <Viewbox Width="16"
+                             Height="16"
+                             Margin="0,0,10,0">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource AccentColorBrush}"
+                                  Data="{StaticResource StatusBarIcon}" />
                         </Canvas>
                     </Viewbox>
 
-                    <TextBlock VerticalAlignment="Center" Margin="10,0,0,0"
+                    <TextBlock VerticalAlignment="Center"
+                               Margin="10,0,0,0"
                                Text="{Binding LastUpdateCheck, Source={x:Static settings:UserSettings.Default}, Converter={x:Static converters:RelativeDateTimeConverter.Instance}, StringFormat=Last Refresh: {0}}" />
                 </StackPanel>
             </DockPanel>

--- a/FModel/MainWindow.xaml
+++ b/FModel/MainWindow.xaml
@@ -1,5 +1,5 @@
-<adonisControls:AdonisWindow x:Class="FModel.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<Window x:Class="FModel.MainWindow"
+        xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:FModel"
         xmlns:controls="clr-namespace:FModel.Views.Resources.Controls"
@@ -7,40 +7,16 @@
         xmlns:converters="clr-namespace:FModel.Views.Resources.Converters"
         xmlns:settings="clr-namespace:FModel.Settings"
         xmlns:services="clr-namespace:FModel.Services"
-        xmlns:adonisUi="clr-namespace:AdonisUI;assembly=AdonisUI"
-        xmlns:adonisControls="clr-namespace:AdonisUI.Controls;assembly=AdonisUI"
-        xmlns:adonisExtensions="clr-namespace:AdonisUI.Extensions;assembly=AdonisUI"
-        WindowStartupLocation="CenterScreen" Closing="OnClosing" Loaded="OnLoaded" PreviewKeyDown="OnWindowKeyDown"
-        Height="{Binding Source={x:Static SystemParameters.MaximizedPrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.95'}"
-        Width="{Binding Source={x:Static SystemParameters.MaximizedPrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.90'}">
-    <Window.TaskbarItemInfo>
-        <TaskbarItemInfo ProgressValue="1.0">
-            <TaskbarItemInfo.ProgressState>
-                <MultiBinding Converter="{converters:StatusToTaskbarStateConverter}">
-                    <Binding Path="Status.Kind" />
-                    <Binding Path="IsActive" RelativeSource="{RelativeSource AncestorType=Window}" />
-                </MultiBinding>
-            </TaskbarItemInfo.ProgressState>
-        </TaskbarItemInfo>
-    </Window.TaskbarItemInfo>
-    <adonisControls:AdonisWindow.Style>
-        <Style TargetType="adonisControls:AdonisWindow" BasedOn="{StaticResource {x:Type adonisControls:AdonisWindow}}" >
-            <Setter Property="Title" Value="{Binding DataContext.InitialWindowTitle, RelativeSource={RelativeSource Self}}" />
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding DataContext.TitleExtra, RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsNullToBoolReversedConverter.Instance}}" Value="True">
-                    <Setter Property="Title">
-                        <Setter.Value>
-                            <MultiBinding StringFormat="{}{0} - {1} {2}">
-                                <Binding Path="DataContext.InitialWindowTitle" RelativeSource="{RelativeSource Self}" />
-                                <Binding Path="DataContext.GameDisplayName" RelativeSource="{RelativeSource Self}" />
-                                <Binding Path="DataContext.TitleExtra" RelativeSource="{RelativeSource Self}" />
-                            </MultiBinding>
-                        </Setter.Value>
-                    </Setter>
-                </DataTrigger>
-            </Style.Triggers>
-        </Style>
-    </adonisControls:AdonisWindow.Style>
+        WindowStartupLocation="CenterScreen"
+        Closing="OnClosing"
+        Loaded="OnLoaded"
+        KeyDown="OnWindowKeyDown"
+        Width="1400" Height="900">
+    <!--
+        Title is set in code-behind (OnLoaded / property change) to replicate the
+        DataTrigger-based title logic that was in the WPF AdonisWindow style.
+        TaskbarItemInfo (Windows-only) is handled in code-behind with an OS guard.
+    -->
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -61,7 +37,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource DirectoryIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource DirectoryIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -70,7 +46,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource KeyIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource KeyIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -79,7 +55,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource BackupIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource BackupIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -88,7 +64,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource InfoIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource InfoIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -99,7 +75,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource SearchIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource SearchIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -108,7 +84,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource SearchIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource SearchIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -117,7 +93,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource DirectoriesIcon}" />
+                                    <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource DirectoriesIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -128,7 +104,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource MeshIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource MeshIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -137,7 +113,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource AudioIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource AudioIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -146,7 +122,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource ImageMergerIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource ImageMergerIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -158,7 +134,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource GiftIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource GiftIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -167,7 +143,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource GitHubIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource GitHubIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -176,7 +152,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource BugIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource BugIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -185,7 +161,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource DiscordIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource DiscordIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -194,7 +170,7 @@
                         <MenuItem.Icon>
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource InfoIcon}" />
+                                    <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource InfoIcon}" />
                                 </Canvas>
                             </Viewbox>
                         </MenuItem.Icon>
@@ -211,7 +187,7 @@
                 <TextBlock Grid.Column="0" Text="Preview New Explorer System" VerticalAlignment="Center" />
                 <CheckBox Grid.Column="1" Margin="5 2 5 0" Unchecked="FeaturePreviewOnUnchecked" KeyboardNavigation.TabNavigation="None" KeyboardNavigation.ControlTabNavigation="None"
                           IsChecked="{Binding FeaturePreviewNewAssetExplorer, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}"
-                          Style="{DynamicResource {x:Static adonisUi:Styles.ToggleSwitch}}"/>
+                          />
             </Grid>
         </Grid>
 
@@ -222,7 +198,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <GroupBox Grid.Column="0" adonisExtensions:LayerExtension.Layer="2"
+            <GroupBox Grid.Column="0"
                       Padding="0" Background="Transparent">
                 <TabControl x:Name="LeftTabControl" SelectionChanged="OnTabItemChange" SelectedIndex="{Binding SelectedLeftTabIndex, Mode=TwoWay}">
                     <TabItem Style="{StaticResource TabItemFillSpace}" Header="Archives">
@@ -261,7 +237,7 @@
                                 </Grid.RowDefinitions>
 
                                 <Separator Grid.Row="0" Style="{StaticResource CustomSeparator}" Tag="GAME ARCHIVES" />
-                                <ListBox Grid.Row="1" x:Name="DirectoryFilesListBox" Style="{StaticResource DirectoryFilesListBox}" MouseDoubleClick="OnMouseDoubleClick" />
+                                <ListBox Grid.Row="1" x:Name="DirectoryFilesListBox" Style="{StaticResource DirectoryFilesListBox}" DoubleTapped="OnMouseDoubleClick" />
                                 <Separator Grid.Row="2" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
                                 <StackPanel Grid.Row="3" Orientation="Vertical" Margin="0 0 0 5">
                                     <Grid HorizontalAlignment="Stretch">
@@ -321,27 +297,27 @@
                                     </TextBlock>
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                                    <Button Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" ToolTip="Bring Selected Folder To View" Padding="4"
+                                    <Button  ToolTip="Bring Selected Folder To View" Padding="4"
                                             Command="{Binding MenuCommand}" CommandParameter="{Binding SelectedItem, ElementName=AssetsFolderName}">
                                         <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
                                             <Canvas Width="24" Height="24">
-                                                <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource LocateMeIcon}" />
+                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource LocateMeIcon}" />
                                             </Canvas>
                                         </Viewbox>
                                     </Button>
-                                    <!-- <Button Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" ToolTip="Expand All (not appropriate for huge amount of folders)" Padding="4" -->
+                                    <!-- <Button  ToolTip="Expand All (not appropriate for huge amount of folders)" Padding="4" -->
                                     <!--         Command="{Binding MenuCommand}" CommandParameter="ToolBox_Expand_All"> -->
                                     <!--     <Viewbox Width="16" Height="16" HorizontalAlignment="Center"> -->
                                     <!--         <Canvas Width="24" Height="24"> -->
-                                    <!--             <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource UnfoldIcon}" /> -->
+                                    <!--             <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource UnfoldIcon}" /> -->
                                     <!--         </Canvas> -->
                                     <!--     </Viewbox> -->
                                     <!-- </Button> -->
-                                    <Button Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" ToolTip="Collapse All" Padding="4"
+                                    <Button  ToolTip="Collapse All" Padding="4"
                                             Command="{Binding MenuCommand}" CommandParameter="ToolBox_Collapse_All">
                                         <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
                                             <Canvas Width="24" Height="24">
-                                                <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource FoldIcon}"/>
+                                                <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource FoldIcon}"/>
                                             </Canvas>
                                         </Viewbox>
                                     </Button>
@@ -351,9 +327,9 @@
                             <TreeView Grid.Row="2"
                                       x:Name="AssetsFolderName"
                                       Style="{StaticResource AssetsFolderTreeView}"
-                                      SelectedItemChanged="OnAssetsTreeSelectedItemChanged"
-                                      PreviewKeyDown="OnFoldersPreviewKeyDown"
-                                      PreviewMouseDoubleClick="OnAssetsTreeMouseDoubleClick">
+                                      SelectionChanged="OnAssetsTreeSelectedItemChanged"
+                                      KeyDown="OnFoldersPreviewKeyDown"
+                                      DoubleTapped="OnAssetsTreeMouseDoubleClick">
                             </TreeView>
                             <Separator Grid.Row="3" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
                             <StackPanel Grid.Row="4" Orientation="Vertical" Margin="0 0 0 5">
@@ -390,7 +366,7 @@
                         <DockPanel>
 
                             <inputs:SearchTextBox DockPanel.Dock="Top" x:Name="AssetsSearchTextBox"
-                                                  Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                  Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay}"
                                                   ClearButtonClick="OnClearFilterClick" />
 
                             <Grid DockPanel.Dock="Top">
@@ -407,8 +383,8 @@
 
                                 <ListBox Grid.Row="1" x:Name="AssetsListName"
                                          Style="{StaticResource AssetsListBox}"
-                                         PreviewMouseDoubleClick="OnAssetsListMouseDoubleClick"
-                                         PreviewKeyDown="OnPreviewKeyDown" />
+                                         DoubleTapped="OnAssetsListMouseDoubleClick"
+                                         KeyDown="OnPreviewKeyDown" />
 
                                 <Separator Grid.Row="2" Style="{StaticResource CustomSeparator}" Tag="INFORMATION" />
                                 <StackPanel Grid.Row="3" Orientation="Vertical" Margin="0 0 0 5">
@@ -444,10 +420,10 @@
             </GroupBox>
 
             <GridSplitter Grid.Column="1" ResizeDirection="Columns" Width="4" VerticalAlignment="Stretch"
-                          ResizeBehavior="PreviousAndNext" MouseDoubleClick="OnGridSplitterDoubleClick"
-                          Background="{DynamicResource {x:Static adonisUi:Brushes.Layer0BackgroundBrush}}" />
+                          ResizeBehavior="PreviousAndNext" DoubleTapped="OnGridSplitterDoubleClick"
+                          Background="{DynamicResource SystemColors.ControlBrushKey}" />
 
-            <GroupBox Grid.Column="2" adonisExtensions:LayerExtension.Layer="2"
+            <GroupBox Grid.Column="2"
                       Padding="0" Background="Transparent">
                 <Grid Margin="0 0 3 0">
                     <Grid.RowDefinitions>
@@ -457,9 +433,9 @@
 
                     <Grid Grid.Row="0">
                         <Border BorderThickness="1" Padding="10"
-                                BorderBrush="{DynamicResource {x:Static adonisUi:Brushes.Layer3BorderBrush}}"
-                                Background="{DynamicResource {x:Static adonisUi:Brushes.Layer3BackgroundBrush}}"
-                                Visibility="{Binding IsAssetsExplorerVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                                
+                                Background="{DynamicResource SystemColors.AppWorkspaceBrushKey}"
+                                IsVisible="{Binding IsAssetsExplorerVisible}">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
@@ -467,7 +443,7 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
 
-                                <Grid Grid.Row="0" adonisExtensions:LayerExtension.Layer="3">
+                                <Grid Grid.Row="0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="5" />
@@ -475,7 +451,7 @@
                                     </Grid.ColumnDefinitions>
 
                                     <inputs:SearchTextBox x:Name="AssetsExplorerSearch" Grid.Column="0"
-                                                          Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                          Text="{Binding SelectedItem.SearchText, ElementName=AssetsFolderName, Mode=TwoWay}"
                                                           ClearButtonClick="OnClearFilterClick" />
 
                                     <ComboBox x:Name="CategoriesSelector" Grid.Column="2"
@@ -490,14 +466,14 @@
                                 <ListBox x:Name="AssetsExplorer" Grid.Row="2"
                                          ItemsSource="{Binding SelectedItem.CombinedEntries, ElementName=AssetsFolderName, IsAsync=True}"
                                          Style="{StaticResource TiledExplorer}"
-                                         Background="{DynamicResource {x:Static adonisUi:Brushes.Layer3BackgroundBrush}}"
-                                         PreviewKeyDown="OnPreviewKeyDown" />
+                                         Background="{DynamicResource SystemColors.AppWorkspaceBrushKey}"
+                                         KeyDown="OnPreviewKeyDown" />
                             </Grid>
                         </Border>
 
                         <TabControl x:Name="TabControlName"
                                     Style="{StaticResource GameFilesTabControl}"
-                                    Visibility="{Binding IsAssetsExplorerVisible, Converter={x:Static converters:InvertBoolToVisibilityConverter.Instance}, ConverterParameter=Hidden}" />
+                                    IsVisible="{Binding IsAssetsExplorerVisible, Converter={x:Static converters:InvertBooleanConverter.Instance}}" />
                     </Grid>
 
                     <Border Grid.Row="0"
@@ -505,31 +481,20 @@
                             HorizontalAlignment="Right"
                             Margin="12,12,20,12"
                             Opacity="0.5"
-                            Visibility="{Binding FeaturePreviewNewAssetExplorer, Source={x:Static settings:UserSettings.Default}, Converter={StaticResource BoolToVisibilityConverter}}"
-                            Background="{DynamicResource {x:Static adonisUi:Brushes.Layer2BackgroundBrush}}"
+                            IsVisible="{Binding FeaturePreviewNewAssetExplorer, Source={x:Static settings:UserSettings.Default}}"
                             CornerRadius="8"
-                            Padding="4"
-                            Effect="{DynamicResource ShadowEffect}">
-                        <Border.Triggers>
-                            <EventTrigger RoutedEvent="MouseEnter">
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                                         To="1"
-                                                         Duration="0:0:0.2" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </EventTrigger>
-                            <EventTrigger RoutedEvent="MouseLeave">
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                                         To="0.5"
-                                                         Duration="0:0:0.2" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </EventTrigger>
-                        </Border.Triggers>
+                            Padding="4">
+                        <!-- Opacity fade replaces WPF Storyboard EventTriggers on MouseEnter/Leave -->
+                        <Border.Transitions>
+                            <Transitions>
+                                <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
+                            </Transitions>
+                        </Border.Transitions>
+                        <Border.Styles>
+                            <Style Selector="Border:pointerover">
+                                <Setter Property="Opacity" Value="1" />
+                            </Style>
+                        </Border.Styles>
                         <StackPanel Orientation="Horizontal"
                                     HorizontalAlignment="Center">
                             <ToggleButton Width="32"
@@ -537,35 +502,27 @@
                                           Cursor="Hand"
                                           Margin="0,0,2,0"
                                           IsChecked="{Binding IsAssetsExplorerVisible, Mode=TwoWay}"
-                                          Style="{StaticResource AssetsExplorerToggleButtonStyle}" />
+                                          Theme="{StaticResource AssetsExplorerToggleButtonStyle}" />
                             <ToggleButton Width="32"
                                           Height="32"
                                           Cursor="Hand"
-                                          Checked="OnPreviewTexturesToggled"
+                                          IsCheckedChanged="OnPreviewTexturesToggled"
                                           Focusable="False"
+                                          ToolTip.Tip="Preview Textures (OFF)"
                                           IsChecked="{Binding PreviewTexturesAssetExplorer, Source={x:Static settings:UserSettings.Default}, Mode=TwoWay}">
-                                <ToggleButton.Style>
-                                    <Style TargetType="ToggleButton"
-                                           BasedOn="{StaticResource ModernToggleButtonStyle}">
-                                        <Setter Property="ToolTip"
-                                                Value="Preview Textures (OFF)" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked"
-                                                     Value="True">
-                                                <Setter Property="Background"
-                                                        Value="MediumPurple" />
-                                                <Setter Property="ToolTip"
-                                                        Value="Preview Textures (ON)" />
-                                            </Trigger>
-                                        </Style.Triggers>
+                                <ToggleButton.Styles>
+                                    <!-- WPF IsChecked=True trigger: purple background and updated tooltip -->
+                                    <Style Selector="ToggleButton:checked">
+                                        <Setter Property="Background" Value="MediumPurple" />
+                                        <Setter Property="ToolTip.Tip" Value="Preview Textures (ON)" />
                                     </Style>
-                                </ToggleButton.Style>
+                                </ToggleButton.Styles>
                                 <Viewbox Width="16"
                                          Height="16">
                                     <Canvas Width="24"
                                             Height="24">
                                         <Path Data="{StaticResource TextureIconAlt}"
-                                              Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" />
+                                              Fill="{DynamicResource SystemColors.ControlTextBrushKey}" />
                                     </Canvas>
                                 </Viewbox>
                             </ToggleButton>
@@ -583,19 +540,19 @@
 
                             <controls:CustomRichTextBox Grid.Column="0" Grid.ColumnSpan="3" x:Name="LogRtbName" Style="{StaticResource CustomRichTextBox}" />
                             <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Bottom" Margin="-5 -5 5 5">
-                                <Button Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" ToolTip="Open Output Folder" Padding="0,4,0,4"
+                                <Button  ToolTip="Open Output Folder" Padding="0,4,0,4"
                                         Command="{Binding MenuCommand}" CommandParameter="ToolBox_Open_Output_Directory" Focusable="False">
                                     <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
                                         <Canvas Width="24" Height="24">
-                                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource FolderIcon}" />
+                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource FolderIcon}" />
                                         </Canvas>
                                     </Viewbox>
                                 </Button>
-                                <Button Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" ToolTip="Clear Logs" Padding="0,4,0,4"
+                                <Button  ToolTip="Clear Logs" Padding="0,4,0,4"
                                         Command="{Binding MenuCommand}" CommandParameter="ToolBox_Clear_Logs" Focusable="False">
                                     <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
                                         <Canvas Width="24" Height="24">
-                                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource TrashIcon}"/>
+                                            <Path Fill="{DynamicResource SystemColors.ControlTextBrushKey}" Data="{StaticResource TrashIcon}"/>
                                         </Canvas>
                                     </Viewbox>
                                 </Button>
@@ -606,108 +563,32 @@
             </GroupBox>
         </Grid>
 
-        <StatusBar Grid.Row="3" MinHeight="28" MaxHeight="28"
-                   adonisExtensions:LayerExtension.Layer="3">
-            <StatusBar.Style>
-                <Style TargetType="{x:Type StatusBar}" BasedOn="{StaticResource {x:Type StatusBar}}">
-                    <Style.Triggers>
-                        <!--don't mind me, MultiDataTrigger just sucks-->
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Ready}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.AccentBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Completed}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.AccentBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Loading}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.AlertBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Stopping}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.AlertBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Stopped}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.ErrorBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Failed}">
-                            <Setter Property="Background" Value="{DynamicResource {x:Static adonisUi:Brushes.ErrorBrush}}" />
-                            <Setter Property="Foreground" Value="White" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding StatusChangeAttempted, Source={x:Static services:ApplicationService.ThreadWorkerView}}" Value="True">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard Duration="0:0:0.8">
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(StatusBar.Background).(SolidColorBrush.Color)" FillBehavior="Stop">
-                                            <ColorAnimationUsingKeyFrames.KeyFrames>
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0" Value="#CE5555" />
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0.2" Value="#C22B2B" />
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0.4" Value="#CE5555" />
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0.6" Value="#C22B2B" />
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0.8" Value="#CE5555" />
-                                            </ColorAnimationUsingKeyFrames.KeyFrames>
-                                        </ColorAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </DataTrigger.EnterActions>
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding OperationCancelled, Source={x:Static services:ApplicationService.ThreadWorkerView}}" Value="True">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard Duration="0:0:1">
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(StatusBar.Background).(SolidColorBrush.Color)" FillBehavior="Stop">
-                                            <ColorAnimationUsingKeyFrames.KeyFrames>
-                                                <DiscreteColorKeyFrame KeyTime="0:0:0" Value="#C22B2B" />
-                                                <DiscreteColorKeyFrame KeyTime="0:0:1" Value="#CE5555" />
-                                            </ColorAnimationUsingKeyFrames.KeyFrames>
-                                        </ColorAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </DataTrigger.EnterActions>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </StatusBar.Style>
+        <!--
+            StatusBar: WPF StatusBar/StatusBarItem and Style.Triggers/DataTriggers
+            replaced with a Border+DockPanel. Background colour is set from
+            code-behind (UpdateStatusBarColor) when Status.Kind changes; the
+            flash animations (StatusChangeAttempted, OperationCancelled) are
+            also handled in code-behind via DispatcherTimer.
+        -->
+        <Border x:Name="StatusBarBorder" Grid.Row="3" MinHeight="28" MaxHeight="28"
+                Padding="5,0">
+            <DockPanel LastChildFill="False">
+                <TextBlock x:Name="StatusLabel"
+                           DockPanel.Dock="Left"
+                           VerticalAlignment="Center"
+                           Text="{Binding Status.Label}" />
 
-            <StatusBarItem Margin="5,0,0,0" >
-                <TextBlock>
-                    <TextBlock.Style>
-                        <Style TargetType="{x:Type TextBlock}">
-                            <Setter Property="Text" Value="{Binding Status.Label}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Loading}">
-                                    <Setter Property="Text" Value="{Binding Status.Label, StringFormat='{}{0} …'}" />
-                                </DataTrigger>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding CanBeCanceled, Source={x:Static services:ApplicationService.ThreadWorkerView}}" Value="True" />
-                                        <Condition Binding="{Binding Status.Kind}" Value="{x:Static local:EStatusKind.Loading}" />
-                                    </MultiDataTrigger.Conditions>
-                                    <Setter Property="Text" Value="{Binding Status.Label, StringFormat='{}{0} …    ESC to Cancel'}" />
-                                </MultiDataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </StatusBarItem>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Viewbox Width="16" Height="16" Margin="0,0,10,0">
+                        <Canvas Width="24" Height="24">
+                            <Path Fill="{DynamicResource AccentColorBrush}" Data="{StaticResource StatusBarIcon}" />
+                        </Canvas>
+                    </Viewbox>
 
-            <StatusBarItem Margin="0 0 5 0" HorizontalAlignment="Right">
-                <StackPanel Orientation="Horizontal">
-                    <StatusBarItem Margin="0 0 10 0" HorizontalContentAlignment="Stretch">
-                        <Viewbox Width="16" Height="16">
-                            <Canvas Width="24" Height="24">
-                                <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource StatusBarIcon}" />
-                            </Canvas>
-                        </Viewbox>
-                    </StatusBarItem>
-
-                    <StatusBarItem Margin="10 0 0 0">
-                        <TextBlock Text="{Binding LastUpdateCheck, Source={x:Static local:Settings.UserSettings.Default}, Converter={x:Static converters:RelativeDateTimeConverter.Instance}, StringFormat=Last Refresh: {0}}" />
-                    </StatusBarItem>
+                    <TextBlock VerticalAlignment="Center" Margin="10,0,0,0"
+                               Text="{Binding LastUpdateCheck, Source={x:Static settings:UserSettings.Default}, Converter={x:Static converters:RelativeDateTimeConverter.Instance}, StringFormat=Last Refresh: {0}}" />
                 </StackPanel>
-            </StatusBarItem>
-        </StatusBar>
+            </DockPanel>
+        </Border>
     </Grid>
-</adonisControls:AdonisWindow>
+</Window>

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -71,7 +71,7 @@ public partial class MainWindow : Window
         if (e.PropertyName is nameof(ApplicationViewModel.TitleExtra)
                            or nameof(ApplicationViewModel.GameDisplayName)
                            or nameof(ApplicationViewModel.InitialWindowTitle))
-            UpdateWindowTitle();
+            Dispatcher.UIThread.InvokeAsync(UpdateWindowTitle);
     }
 
     // --- Status bar colour (replaces WPF DataTrigger style) ---
@@ -79,38 +79,44 @@ public partial class MainWindow : Window
     private void OnStatusKindChanged(object sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(FStatus.Kind))
-            UpdateStatusBarColor();
+            Dispatcher.UIThread.InvokeAsync(UpdateStatusBarColor);
+        else if (e.PropertyName == nameof(FStatus.Label))
+            Dispatcher.UIThread.InvokeAsync(UpdateStatusLabel);
     }
 
     private void UpdateStatusBarColor()
     {
-        if (StatusBarBorder is null) return;
-        var (bg, fg) = _applicationView.Status.Kind switch
+        if (StatusBarBorder is null)
+            return;
+        var brushKey = _applicationView.Status.Kind switch
         {
-            EStatusKind.Ready or EStatusKind.Completed =>
-                (Application.Current!.FindResource("AccentColorBrush") as IBrush, Brushes.White),
-            EStatusKind.Loading or EStatusKind.Stopping =>
-                (Application.Current!.FindResource("AlertColorBrush") as IBrush, Brushes.White),
-            EStatusKind.Stopped or EStatusKind.Failed =>
-                (Application.Current!.FindResource("ErrorColorBrush") as IBrush, Brushes.White),
-            _ => ((IBrush?)null, (IBrush?)null)
+            EStatusKind.Ready or EStatusKind.Completed => "AccentColorBrush",
+            EStatusKind.Loading or EStatusKind.Stopping => "AlertColorBrush",
+            EStatusKind.Stopped or EStatusKind.Failed => "ErrorColorBrush",
+            _ => (string?) null
         };
-        if (bg != null) StatusBarBorder.Background = bg;
-        if (fg != null) StatusBarBorder.Foreground = fg;
+        if (brushKey is null)
+            return;
+        if (Application.Current!.TryGetResource(brushKey, ActualThemeVariant, out var resource)
+            && resource is IBrush bg)
+        {
+            StatusBarBorder.Background = bg;
+            StatusBarBorder.Foreground = Brushes.White;
+        }
     }
 
     private void OnThreadWorkerPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         // Flash animations for StatusChangeAttempted / OperationCancelled
         // are tracked as TODO: implement via DispatcherTimer in a later pass.
-        if (e.PropertyName == nameof(ThreadWorkerViewModel.CanBeCanceled)
-            || e.PropertyName == nameof(ThreadWorkerViewModel.CanBeCanceled))
-            UpdateStatusLabel();
+        if (e.PropertyName == nameof(ThreadWorkerViewModel.CanBeCanceled))
+            Dispatcher.UIThread.InvokeAsync(UpdateStatusLabel);
     }
 
     private void UpdateStatusLabel()
     {
-        if (StatusLabel is null) return;
+        if (StatusLabel is null)
+            return;
         var kind = _applicationView.Status.Kind;
         var label = _applicationView.Status.Label;
         StatusLabel.Text = kind == EStatusKind.Loading && _threadWorkerView.CanBeCanceled
@@ -134,7 +140,7 @@ public partial class MainWindow : Window
         var screen = Screens.Primary;
         if (screen != null)
         {
-            Width  = screen.WorkingArea.Width  * 0.90 / screen.PixelDensity;
+            Width = screen.WorkingArea.Width * 0.90 / screen.PixelDensity;
             Height = screen.WorkingArea.Height * 0.95 / screen.PixelDensity;
         }
 
@@ -307,7 +313,8 @@ public partial class MainWindow : Window
 
     private void OnAssetsTreeMouseDoubleClick(object sender, TappedEventArgs e)
     {
-        if (sender is not TreeView { SelectedItem: TreeItem treeItem } || treeItem.Folders.Count > 0) return;
+        if (sender is not TreeView { SelectedItem: TreeItem treeItem } || treeItem.Folders.Count > 0)
+            return;
         _applicationView.SelectedLeftTabIndex++;
     }
 
@@ -324,7 +331,8 @@ public partial class MainWindow : Window
             var container = listBox.ContainerFromIndex(i) as Control;
             if (container == null)
             {
-                if (foundVisibleItem) break;
+                if (foundVisibleItem)
+                    break;
                 continue;
             }
 
@@ -338,7 +346,8 @@ public partial class MainWindow : Window
 
     private void OnAssetsTreeSelectedItemChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (sender is not TreeView { SelectedItem: TreeItem }) return;
+        if (sender is not TreeView { SelectedItem: TreeItem })
+            return;
 
         _applicationView.IsAssetsExplorerVisible = true;
         _applicationView.SelectedLeftTabIndex = 1;
@@ -346,10 +355,12 @@ public partial class MainWindow : Window
 
     private async void OnAssetsListMouseDoubleClick(object sender, TappedEventArgs e)
     {
-        if (sender is not ListBox listBox) return;
+        if (sender is not ListBox listBox)
+            return;
 
         var selectedItems = listBox.SelectedItems?.OfType<GameFileViewModel>().Select(gvm => gvm.Asset).ToArray();
-        if (selectedItems == null || selectedItems.Length == 0) return;
+        if (selectedItems == null || selectedItems.Length == 0)
+            return;
 
         await _threadWorkerView.Begin(cancellationToken => { _applicationView.CUE4Parse.ExtractSelected(cancellationToken, selectedItems); });
     }
@@ -365,7 +376,8 @@ public partial class MainWindow : Window
 
     private void OnMouseDoubleClick(object sender, TappedEventArgs e)
     {
-        if (!_applicationView.Status.IsReady || sender is not ListBox listBox) return;
+        if (!_applicationView.Status.IsReady || sender is not ListBox listBox)
+            return;
         UserSettings.Default.LoadingMode = ELoadingMode.Multiple;
         _applicationView.LoadingModes.LoadCommand.Execute(listBox.SelectedItems);
     }

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -1,24 +1,27 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
 using FModel.Services;
 using FModel.Settings;
 using FModel.ViewModels;
 using FModel.Views;
 using FModel.Views.Resources.Controls;
-using ICSharpCode.AvalonEdit.Editing;
+using AvaloniaEdit.Editing;
 
 namespace FModel;
 
 /// <summary>
 /// Interaction logic for MainWindow.xaml
 /// </summary>
-public partial class MainWindow
+public partial class MainWindow : Window
 {
     public static MainWindow YesWeCats;
     private ThreadWorkerViewModel _threadWorkerView => ApplicationService.ThreadWorkerView;
@@ -27,55 +30,97 @@ public partial class MainWindow
 
     public MainWindow()
     {
-        CommandBindings.Add(new CommandBinding(new RoutedCommand("ReloadMappings", typeof(MainWindow), new InputGestureCollection { new KeyGesture(Key.F12) }), OnMappingsReload));
-        CommandBindings.Add(new CommandBinding(ApplicationCommands.Find, (_, _) => OnOpenAvalonFinder()));
-        CommandBindings.Add(new CommandBinding(NavigationCommands.BrowseBack, (_, _) =>
-        {
-            if (UserSettings.Default.FeaturePreviewNewAssetExplorer && !_applicationView.IsAssetsExplorerVisible)
-            {
-                // back browsing the json view will reopen the assets explorer
-                _applicationView.IsAssetsExplorerVisible = true;
-                return;
-            }
-
-            if (LeftTabControl.SelectedIndex == 2)
-            {
-                LeftTabControl.SelectedIndex = 1;
-            }
-            else if (LeftTabControl.SelectedIndex == 1 && AssetsFolderName.SelectedItem is TreeItem { Parent: TreeItem parent })
-            {
-                AssetsFolderName.Focus();
-                parent.IsSelected = true;
-            }
-        }));
-
         DataContext = _applicationView;
         InitializeComponent();
 
-        AssetsExplorer.ItemContainerGenerator.StatusChanged += ItemContainerGenerator_StatusChanged;
-        AssetsListName.ItemContainerGenerator.StatusChanged += ItemContainerGenerator_StatusChanged;
         AssetsExplorer.SelectionChanged += (_, e) => SyncSelection(AssetsListName, e);
         AssetsListName.SelectionChanged += (_, e) => SyncSelection(AssetsExplorer, e);
 
         FLogger.Logger = LogRtbName;
         YesWeCats = this;
+
+        // Wire status-bar colour updates; replaces WPF DataTrigger-based style
+        _applicationView.Status.PropertyChanged += OnStatusKindChanged;
+        _threadWorkerView.PropertyChanged += OnThreadWorkerPropertyChanged;
+
+        // Wire window title updates; replaces WPF DataTrigger on AdonisWindow style
+        _applicationView.PropertyChanged += OnApplicationViewPropertyChanged;
+        UpdateWindowTitle();
+
+        // Windows-only: set up TaskbarItemInfo progress
+        if (OperatingSystem.IsWindows())
+            InitTaskbarInfo();
     }
 
-    // Hack to sync selection between packages tab and explorer
-    private void SyncSelection(ListBox target, SelectionChangedEventArgs e)
+    [SupportedOSPlatform("windows")]
+    private void InitTaskbarInfo()
     {
-        foreach (var added in e.AddedItems.OfType<GameFileViewModel>())
-        {
-            if (!target.SelectedItems.Contains(added))
-                target.SelectedItems.Add(added);
-        }
-
-        foreach (var removed in e.RemovedItems.OfType<GameFileViewModel>())
-        {
-            if (target.SelectedItems.Contains(removed))
-                target.SelectedItems.Remove(removed);
-        }
+        // TODO(P2-015): set up Windows taskbar progress indicator once
+        // StatusToTaskbarStateConverter is migrated.
     }
+
+    private void UpdateWindowTitle()
+    {
+        Title = string.IsNullOrEmpty(_applicationView.TitleExtra)
+            ? _applicationView.InitialWindowTitle
+            : $"{_applicationView.InitialWindowTitle} - {_applicationView.GameDisplayName} {_applicationView.TitleExtra}";
+    }
+
+    private void OnApplicationViewPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ApplicationViewModel.TitleExtra)
+                           or nameof(ApplicationViewModel.GameDisplayName)
+                           or nameof(ApplicationViewModel.InitialWindowTitle))
+            UpdateWindowTitle();
+    }
+
+    // --- Status bar colour (replaces WPF DataTrigger style) ---
+
+    private void OnStatusKindChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(FStatus.Kind))
+            UpdateStatusBarColor();
+    }
+
+    private void UpdateStatusBarColor()
+    {
+        if (StatusBarBorder is null) return;
+        var (bg, fg) = _applicationView.Status.Kind switch
+        {
+            EStatusKind.Ready or EStatusKind.Completed =>
+                (Application.Current!.FindResource("AccentColorBrush") as IBrush, Brushes.White),
+            EStatusKind.Loading or EStatusKind.Stopping =>
+                (Application.Current!.FindResource("AlertColorBrush") as IBrush, Brushes.White),
+            EStatusKind.Stopped or EStatusKind.Failed =>
+                (Application.Current!.FindResource("ErrorColorBrush") as IBrush, Brushes.White),
+            _ => ((IBrush?)null, (IBrush?)null)
+        };
+        if (bg != null) StatusBarBorder.Background = bg;
+        if (fg != null) StatusBarBorder.Foreground = fg;
+    }
+
+    private void OnThreadWorkerPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        // Flash animations for StatusChangeAttempted / OperationCancelled
+        // are tracked as TODO: implement via DispatcherTimer in a later pass.
+        if (e.PropertyName == nameof(ThreadWorkerViewModel.CanBeCanceled)
+            || e.PropertyName == nameof(ThreadWorkerViewModel.CanBeCanceled))
+            UpdateStatusLabel();
+    }
+
+    private void UpdateStatusLabel()
+    {
+        if (StatusLabel is null) return;
+        var kind = _applicationView.Status.Kind;
+        var label = _applicationView.Status.Label;
+        StatusLabel.Text = kind == EStatusKind.Loading && _threadWorkerView.CanBeCanceled
+            ? $"{label} \u2026    ESC to Cancel"
+            : kind == EStatusKind.Loading
+                ? $"{label} \u2026"
+                : label;
+    }
+
+    // --- Lifecycle ---
 
     private void OnClosing(object sender, CancelEventArgs e)
     {
@@ -84,6 +129,17 @@ public partial class MainWindow
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
+        // Set initial window size to ~90%×95% of primary screen working area
+        // (replaces WPF SystemParameters binding)
+        var screen = Screens.Primary;
+        if (screen != null)
+        {
+            Width  = screen.WorkingArea.Width  * 0.90 / screen.PixelDensity;
+            Height = screen.WorkingArea.Height * 0.95 / screen.PixelDensity;
+        }
+
+        UpdateStatusBarColor();
+
         var newOrUpdated = UserSettings.Default.ShowChangelog;
 #if !DEBUG
         ApplicationService.ApiEndpointView.FModelApi.CheckForUpdates(true);
@@ -125,42 +181,47 @@ public partial class MainWindow
                     _discordHandler.Initialize(_applicationView.GameDisplayName);
             })
         ).ConfigureAwait(false);
-
-#if DEBUG
-        // await _threadWorkerView.Begin(cancellationToken =>
-        //     _applicationView.CUE4Parse.Extract(cancellationToken,
-        //         _applicationView.CUE4Parse.Provider["Marvel/Content/Marvel/Wwise/Assets/Events/Music/music_new/event/Entry.uasset"]));
-#endif
     }
 
-    private void OnGridSplitterDoubleClick(object sender, MouseButtonEventArgs e)
+    private void OnGridSplitterDoubleClick(object sender, TappedEventArgs e)
     {
         RootGrid.ColumnDefinitions[0].Width = GridLength.Auto;
     }
 
     private void OnWindowKeyDown(object sender, KeyEventArgs e)
     {
-        if (e.OriginalSource is TextBox || e.OriginalSource is TextArea && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
-            return;
+        if (e.Source is TextBox || e.Source is TextArea)
+        {
+            // Let Ctrl+key through to the text editing controls
+            if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
+                return;
+        }
 
         if (_threadWorkerView.CanBeCanceled && e.Key == Key.Escape)
         {
             _applicationView.Status.SetStatus(EStatusKind.Stopping);
             _threadWorkerView.Cancel();
         }
-        else if (_applicationView.Status.IsReady && e.Key == Key.F && Keyboard.Modifiers.HasFlag(ModifierKeys.Control) && Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+        else if (_applicationView.Status.IsReady && e.Key == Key.F
+                 && e.KeyModifiers.HasFlag(KeyModifiers.Control)
+                 && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             OnSearchViewClick(null, null);
-        else if (_applicationView.Status.IsReady && e.Key == Key.R && Keyboard.Modifiers.HasFlag(ModifierKeys.Control) && Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+        else if (_applicationView.Status.IsReady && e.Key == Key.R
+                 && e.KeyModifiers.HasFlag(KeyModifiers.Control)
+                 && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             OnRefViewClick(null, null);
         else if (e.Key == Key.F3)
             OnOpenAvalonFinder();
-        else if (e.Key == Key.Left && !_applicationView.IsAssetsExplorerVisible && _applicationView.CUE4Parse.TabControl.SelectedTab is { HasImage: true })
+        else if (e.Key == Key.Left && !_applicationView.IsAssetsExplorerVisible
+                 && _applicationView.CUE4Parse.TabControl.SelectedTab is { HasImage: true })
             _applicationView.CUE4Parse.TabControl.SelectedTab.GoPreviousImage();
-        else if (e.Key == Key.Right && !_applicationView.IsAssetsExplorerVisible && _applicationView.CUE4Parse.TabControl.SelectedTab is { HasImage: true })
+        else if (e.Key == Key.Right && !_applicationView.IsAssetsExplorerVisible
+                 && _applicationView.CUE4Parse.TabControl.SelectedTab is { HasImage: true })
             _applicationView.CUE4Parse.TabControl.SelectedTab.GoNextImage();
-        else if (_applicationView.Status.IsReady && _applicationView.IsAssetsExplorerVisible && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+        else if (_applicationView.Status.IsReady && _applicationView.IsAssetsExplorerVisible
+                 && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
-            CategoriesSelector.SelectedIndex = e.SystemKey switch
+            CategoriesSelector.SelectedIndex = e.Key switch
             {
                 Key.D0 or Key.NumPad0 => 0,
                 Key.D1 or Key.NumPad1 => 1,
@@ -175,7 +236,9 @@ public partial class MainWindow
                 _ => CategoriesSelector.SelectedIndex
             };
         }
-        else if (_applicationView.Status.IsReady && UserSettings.Default.FeaturePreviewNewAssetExplorer && UserSettings.Default.SwitchAssetExplorer.IsTriggered(e.Key))
+        else if (_applicationView.Status.IsReady
+                 && UserSettings.Default.FeaturePreviewNewAssetExplorer
+                 && UserSettings.Default.SwitchAssetExplorer.IsTriggered(e.Key))
             _applicationView.IsAssetsExplorerVisible = !_applicationView.IsAssetsExplorerVisible;
         else if (UserSettings.Default.AssetAddTab.IsTriggered(e.Key))
             _applicationView.CUE4Parse.TabControl.AddTab();
@@ -189,6 +252,11 @@ public partial class MainWindow
             _applicationView.SelectedLeftTabIndex--;
         else if (UserSettings.Default.DirRightTab.IsTriggered(e.Key) && _applicationView.SelectedLeftTabIndex < LeftTabControl.Items.Count - 1)
             _applicationView.SelectedLeftTabIndex++;
+    }
+
+    private void OnMappingsReload(object sender, RoutedEventArgs e)
+    {
+        _ = _applicationView.CUE4Parse.InitMappings(true);
     }
 
     private void OnSearchViewClick(object sender, RoutedEventArgs e)
@@ -205,7 +273,7 @@ public partial class MainWindow
 
     private void OnTabItemChange(object sender, SelectionChangedEventArgs e)
     {
-        if (e.OriginalSource is not TabControl tabControl)
+        if (e.Source is not TabControl tabControl)
             return;
 
         switch (tabControl.SelectedIndex)
@@ -220,11 +288,6 @@ public partial class MainWindow
                 AssetsListName.Focus();
                 break;
         }
-    }
-
-    private async void OnMappingsReload(object sender, ExecutedRoutedEventArgs e)
-    {
-        await _applicationView.CUE4Parse.InitMappings(true);
     }
 
     private void OnOpenAvalonFinder()
@@ -242,32 +305,30 @@ public partial class MainWindow
         }
     }
 
-    private void OnAssetsTreeMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    private void OnAssetsTreeMouseDoubleClick(object sender, TappedEventArgs e)
     {
         if (sender is not TreeView { SelectedItem: TreeItem treeItem } || treeItem.Folders.Count > 0) return;
-
         _applicationView.SelectedLeftTabIndex++;
     }
 
-    private void OnPreviewTexturesToggled(object sender, RoutedEventArgs e) => ItemContainerGenerator_StatusChanged(AssetsExplorer.ItemContainerGenerator, EventArgs.Empty);
-    private void ItemContainerGenerator_StatusChanged(object sender, EventArgs e)
+    private void OnPreviewTexturesToggled(object sender, RoutedEventArgs e) =>
+        ItemContainerGenerator_StatusChanged(AssetsExplorer);
+
+    private void ItemContainerGenerator_StatusChanged(ListBox listBox)
     {
-        if (sender is not ItemContainerGenerator { Status: GeneratorStatus.ContainersGenerated } generator)
-            return;
-
+        // Avalonia doesn't have ItemContainerGenerator; containers are always
+        // available once rendered. Walk visible items instead.
         var foundVisibleItem = false;
-        var itemCount = generator.Items.Count;
-
-        for (var i = 0; i < itemCount; i++)
+        for (var i = 0; i < listBox.Items.Count; i++)
         {
-            var container = generator.ContainerFromIndex(i);
+            var container = listBox.ContainerFromIndex(i) as Control;
             if (container == null)
             {
-                if (foundVisibleItem) break; // we're past the visible range already
-                continue; // keep scrolling to find visible items
+                if (foundVisibleItem) break;
+                continue;
             }
 
-            if (container is FrameworkElement { IsVisible: true } && generator.Items[i] is GameFileViewModel file)
+            if (container.IsVisible && listBox.Items[i] is GameFileViewModel file)
             {
                 foundVisibleItem = true;
                 file.OnIsVisible();
@@ -275,7 +336,7 @@ public partial class MainWindow
         }
     }
 
-    private void OnAssetsTreeSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    private void OnAssetsTreeSelectedItemChanged(object sender, SelectionChangedEventArgs e)
     {
         if (sender is not TreeView { SelectedItem: TreeItem }) return;
 
@@ -283,12 +344,12 @@ public partial class MainWindow
         _applicationView.SelectedLeftTabIndex = 1;
     }
 
-    private async void OnAssetsListMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    private async void OnAssetsListMouseDoubleClick(object sender, TappedEventArgs e)
     {
         if (sender is not ListBox listBox) return;
 
-        var selectedItems = listBox.SelectedItems.OfType<GameFileViewModel>().Select(gvm => gvm.Asset).ToArray();
-        if (selectedItems.Length == 0) return;
+        var selectedItems = listBox.SelectedItems?.OfType<GameFileViewModel>().Select(gvm => gvm.Asset).ToArray();
+        if (selectedItems == null || selectedItems.Length == 0) return;
 
         await _threadWorkerView.Begin(cancellationToken => { _applicationView.CUE4Parse.ExtractSelected(cancellationToken, selectedItems); });
     }
@@ -302,7 +363,7 @@ public partial class MainWindow
         }
     }
 
-    private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    private void OnMouseDoubleClick(object sender, TappedEventArgs e)
     {
         if (!_applicationView.Status.IsReady || sender is not ListBox listBox) return;
         UserSettings.Default.LoadingMode = ELoadingMode.Multiple;
@@ -373,5 +434,20 @@ public partial class MainWindow
 
         childFolder.IsExpanded = true;
         childFolder.IsSelected = true;
+    }
+
+    // Hack to sync selection between packages tab and explorer
+    private void SyncSelection(ListBox target, SelectionChangedEventArgs e)
+    {
+        foreach (var added in e.AddedItems.OfType<GameFileViewModel>())
+        {
+            if (target.SelectedItems != null && !target.SelectedItems.Contains(added))
+                target.SelectedItems.Add(added);
+        }
+
+        foreach (var removed in e.RemovedItems.OfType<GameFileViewModel>())
+        {
+            target.SelectedItems?.Remove(removed);
+        }
     }
 }


### PR DESCRIPTION
Closes #15

## Summary

Migrates `MainWindow.xaml` and `MainWindow.xaml.cs` from WPF `AdonisWindow` to Avalonia `Window`, plus the `Helper.cs` and `App.xaml.cs` dependencies called out in the issue.

## Changes

### `MainWindow.xaml`
- Replace `<adonisControls:AdonisWindow>` root with `<Window xmlns="https://github.com/avaloniaui">`
- Remove all `adonisUi`, `adonisControls`, `adonisExtensions` xmlns declarations and attribute usages
- Remove `Window.TaskbarItemInfo` block (handled in code-behind with `[SupportedOSPlatform("windows")]` guard)
- Remove `AdonisWindow.Style` DataTrigger title logic (handled via `PropertyChanged` in code-behind)
- Set static fallback `Width="1400" Height="900"` (overridden at runtime via `Screens.Primary.WorkingArea` in `OnLoaded`)
- Convert event names: `PreviewKeyDown` → `KeyDown`, `MouseDoubleClick` → `DoubleTapped`, `SelectedItemChanged` → `SelectionChanged`
- Replace AdonisUI brush references with Avalonia system brush keys
- Remove all `adonisExtensions:LayerExtension.Layer` attributes
- Remove `UpdateSourceTrigger=PropertyChanged` (Avalonia default)
- Replace `Visibility` + `BoolToVisibilityConverter` with `IsVisible` bool bindings
- Replace WPF `StatusBar`/`StatusBarItem` + `Style.Triggers`/`DataTrigger`/`MultiDataTrigger`/`ColorAnimationUsingKeyFrames` with `Border`+`DockPanel`; colors updated in code-behind
- Replace `Border.Triggers` Storyboard opacity animation with Avalonia `Transitions` + `<Style Selector="Border:pointerover">`
- Replace `ToggleButton.Style` WPF property triggers with `ToggleButton.Styles` using `Selector="ToggleButton:checked"`

### `MainWindow.xaml.cs`
- Switch namespace imports from `System.Windows.*` to `Avalonia.*`
- Remove WPF `CommandBindings` / `RoutedCommand` / `NavigationCommands`
- Update all event handler signatures: `MouseButtonEventArgs` → `TappedEventArgs`, `RoutedPropertyChangedEventArgs<object>` → `SelectionChangedEventArgs`, `ExecutedRoutedEventArgs` → `RoutedEventArgs`
- Replace `e.OriginalSource` → `e.Source`, `Keyboard.Modifiers` → `e.KeyModifiers`, `e.SystemKey` → `e.Key`
- Add `PropertyChanged`-driven `UpdateStatusBarColor()` and `UpdateWindowTitle()` helpers (replace WPF DataTrigger + MultiDataTrigger logic)
- Add `OnLoaded` screen sizing via `Screens.Primary.WorkingArea` (replace `SystemParameters` bindings)
- Add `[SupportedOSPlatform("windows")] InitTaskbarInfo()` stub
- `ItemContainerGenerator` → `listBox.ContainerFromIndex(i)`

### `Helper.cs`
- Replace `Application.Current.Windows.OfType<T>()` (WPF) with `IClassicDesktopStyleApplicationLifetime.Windows.OfType<T>()` via a `GetAllWindows()` helper
- Remove `w.Activate()` (no Avalonia equivalent)
- Null-safe `w.Title?.Equals(name)` for Avalonia's nullable `Title`

### `App.xaml.cs`
- Wire `desktop.MainWindow = new MainWindow()` (replaces `// TODO(#15)` comment)

## Build Impact

Error count: 751 → 725 (26 fewer errors; no new errors introduced in the changed files).