### PR TITLE
feat(P2-004): migrate all 26 IValueConverter/IMultiValueConverter implementations to Avalonia

### DIFF
--- a/FModel/Views/Resources/Converters/AnyItemMeetsConditionConverter.cs
+++ b/FModel/Views/Resources/Converters/AnyItemMeetsConditionConverter.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 using CUE4Parse.UE4.IO.Objects;
 using FModel.Extensions;
 using FModel.ViewModels;

--- a/FModel/Views/Resources/Converters/AnyItemMeetsConditionConverter.cs
+++ b/FModel/Views/Resources/Converters/AnyItemMeetsConditionConverter.cs
@@ -19,7 +19,7 @@ public class AnyItemMeetsConditionConverter : IValueConverter
     /// </summary>
     public EConditionMode ConditionMode { get; set; } = EConditionMode.And;
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not IEnumerable items || Conditions.Count == 0)
             return false;
@@ -34,7 +34,7 @@ public class AnyItemMeetsConditionConverter : IValueConverter
         return items.OfType<GameFileViewModel>().Any(predicate);
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/BoolToRenderModeConverter.cs
+++ b/FModel/Views/Resources/Converters/BoolToRenderModeConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
-using System.Windows.Media;
+using Avalonia.Data.Converters;
+using Avalonia.Media.Imaging;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -9,19 +9,20 @@ public class BoolToRenderModeConverter : IValueConverter
 {
     public static readonly BoolToRenderModeConverter Instance = new();
 
-    public BitmapScalingMode Convert(bool value) => (BitmapScalingMode) Convert(value, null, null, null);
+    public BitmapInterpolationMode Convert(bool value)
+        => (BitmapInterpolationMode) Convert(value, typeof(BitmapInterpolationMode), null, null)!;
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        // WPF BitmapScalingMode.NearestNeighbor → Avalonia BitmapInterpolationMode.None (no filtering)
+        // WPF BitmapScalingMode.Linear          → Avalonia BitmapInterpolationMode.HighQuality
         return value switch
         {
-            true => BitmapScalingMode.NearestNeighbor,
-            _ => BitmapScalingMode.Linear
+            true => BitmapInterpolationMode.None,
+            _    => BitmapInterpolationMode.HighQuality,
         };
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/FModel/Views/Resources/Converters/BoolToRenderModeConverter.cs
+++ b/FModel/Views/Resources/Converters/BoolToRenderModeConverter.cs
@@ -10,7 +10,7 @@ public class BoolToRenderModeConverter : IValueConverter
     public static readonly BoolToRenderModeConverter Instance = new();
 
     public BitmapInterpolationMode Convert(bool value)
-        => (BitmapInterpolationMode) Convert(value, typeof(BitmapInterpolationMode), null, null)!;
+        => value ? BitmapInterpolationMode.None : BitmapInterpolationMode.HighQuality;
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {

--- a/FModel/Views/Resources/Converters/BorderThicknessToStrokeThicknessConverter.cs
+++ b/FModel/Views/Resources/Converters/BorderThicknessToStrokeThicknessConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Data;
+using Avalonia;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -9,14 +9,12 @@ public class BorderThicknessToStrokeThicknessConverter : IValueConverter
 {
     public static readonly BorderThicknessToStrokeThicknessConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var thickness = (Thickness) value;
+        var thickness = value is Thickness t ? t : default;
         return (thickness.Bottom + thickness.Left + thickness.Right + thickness.Top) / 4;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/FModel/Views/Resources/Converters/CommitMessageConverter.cs
+++ b/FModel/Views/Resources/Converters/CommitMessageConverter.cs
@@ -8,7 +8,7 @@ public class CommitMessageConverter : IValueConverter
 {
     public static readonly CommitMessageConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is string commitMessage)
         {
@@ -18,7 +18,7 @@ public class CommitMessageConverter : IValueConverter
         return value;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/CommitMessageConverter.cs
+++ b/FModel/Views/Resources/Converters/CommitMessageConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/DateTimeToDateConverter.cs
+++ b/FModel/Views/Resources/Converters/DateTimeToDateConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/DateTimeToDateConverter.cs
+++ b/FModel/Views/Resources/Converters/DateTimeToDateConverter.cs
@@ -8,7 +8,7 @@ public class DateTimeToDateConverter : IValueConverter
 {
     public static readonly DateTimeToDateConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is DateTime dateTime)
         {
@@ -17,7 +17,7 @@ public class DateTimeToDateConverter : IValueConverter
         return value;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/FileToGeometryConverter.cs
+++ b/FModel/Views/Resources/Converters/FileToGeometryConverter.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Data;
-using System.Windows.Media;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -10,9 +11,9 @@ public class FileToGeometryConverter : IMultiValueConverter
 {
     public static readonly FileToGeometryConverter Instance = new();
 
-    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values.Length < 2 || values[0] is not EAssetCategory category || values[1] is not string resolvedAssetType)
+        if (values.Count < 2 || values[0] is not EAssetCategory category || values[1] is not string resolvedAssetType)
             return null;
 
         resolvedAssetType = resolvedAssetType.ToLowerInvariant();
@@ -96,15 +97,16 @@ public class FileToGeometryConverter : IMultiValueConverter
         };
 
         if (targetType == typeof(Geometry))
-            return Application.Current.FindResource(geometry) as Geometry;
-        if (targetType == typeof(Brush))
-            return Application.Current.FindResource(brush) as Brush;
+        {
+            Application.Current!.TryGetResource(geometry, null, out var geomRes);
+            return geomRes as Geometry;
+        }
+        if (targetType == typeof(IBrush))
+        {
+            Application.Current!.TryGetResource(brush, null, out var brushRes);
+            return brushRes as IBrush;
+        }
 
         return null;
-    }
-
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/FModel/Views/Resources/Converters/FolderToGeometryConverter.cs
+++ b/FModel/Views/Resources/Converters/FolderToGeometryConverter.cs
@@ -47,7 +47,6 @@ public class FolderToGeometryConverter : IValueConverter
         };
 
         if (targetType == typeof(Geometry) && geometry != null)
-        if (targetType == typeof(Geometry) && geometry != null)
         {
             Application.Current!.TryGetResource(geometry, null, out var geomRes);
             return geomRes as Geometry;

--- a/FModel/Views/Resources/Converters/FolderToGeometryConverter.cs
+++ b/FModel/Views/Resources/Converters/FolderToGeometryConverter.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Data;
-using System.Windows.Media;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -10,7 +10,7 @@ public class FolderToGeometryConverter : IValueConverter
 {
     public static readonly FolderToGeometryConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not string folderName)
             return null;
@@ -47,15 +47,20 @@ public class FolderToGeometryConverter : IValueConverter
         };
 
         if (targetType == typeof(Geometry) && geometry != null)
-            return Application.Current.FindResource(geometry) as Geometry;
-        if (targetType == typeof(Brush))
-            return Application.Current.FindResource(brush) as Brush;
+        if (targetType == typeof(Geometry) && geometry != null)
+        {
+            Application.Current!.TryGetResource(geometry, null, out var geomRes);
+            return geomRes as Geometry;
+        }
+        if (targetType == typeof(IBrush))
+        {
+            Application.Current!.TryGetResource(brush, null, out var brushRes);
+            return brushRes as IBrush;
+        }
 
         return null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/FModel/Views/Resources/Converters/FolderToSeparatorTagConverter.cs
+++ b/FModel/Views/Resources/Converters/FolderToSeparatorTagConverter.cs
@@ -8,12 +8,12 @@ public class FolderToSeparatorTagConverter : IValueConverter
 {
     public static readonly FolderToSeparatorTagConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         return value != null ? $"{value.ToString()?.ToUpper()} PACKAGES" : null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/FolderToSeparatorTagConverter.cs
+++ b/FModel/Views/Resources/Converters/FolderToSeparatorTagConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/GameFileMeetsConditionConverter.cs
+++ b/FModel/Views/Resources/Converters/GameFileMeetsConditionConverter.cs
@@ -17,7 +17,7 @@ public class GameFileMeetsConditionConverter : IValueConverter
 {
     public Collection<IGameFileCondition> Conditions { get; } = [];
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var gameFile = value switch
         {
@@ -30,7 +30,7 @@ public class GameFileMeetsConditionConverter : IValueConverter
         return Conditions.All(c => c.Matches(gameFile));
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/GameFileMeetsConditionConverter.cs
+++ b/FModel/Views/Resources/Converters/GameFileMeetsConditionConverter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.UE4.IO.Objects;
 using FModel.ViewModels;

--- a/FModel/Views/Resources/Converters/InvertBoolToVisibilityConverter.cs
+++ b/FModel/Views/Resources/Converters/InvertBoolToVisibilityConverter.cs
@@ -9,9 +9,10 @@ namespace FModel.Views.Resources.Converters;
 /// Avalonia uses <c>IsVisible</c> (bool); the WPF Visibility.Hidden concept
 /// does not exist — both Collapsed and Hidden map to <c>false</c>.
 /// </summary>
-public class InvertBoolToVisibilityConverter : IValueConverter
+/// <remarks>File rename from InvertBoolToVisibilityConverter is deferred; class name takes precedence.</remarks>
+public class InvertBoolConverter : IValueConverter
 {
-    public static readonly InvertBoolToVisibilityConverter Instance = new();
+    public static readonly InvertBoolConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is bool b ? !b : (object) true;

--- a/FModel/Views/Resources/Converters/InvertBoolToVisibilityConverter.cs
+++ b/FModel/Views/Resources/Converters/InvertBoolToVisibilityConverter.cs
@@ -1,30 +1,21 @@
 using System;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
+/// <summary>
+/// Returns the logical negation of the input bool.
+/// Avalonia uses <c>IsVisible</c> (bool); the WPF Visibility.Hidden concept
+/// does not exist — both Collapsed and Hidden map to <c>false</c>.
+/// </summary>
 public class InvertBoolToVisibilityConverter : IValueConverter
 {
     public static readonly InvertBoolToVisibilityConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is bool boolValue)
-        {
-            bool useHidden = parameter?.ToString().Equals("Hidden", StringComparison.OrdinalIgnoreCase) ?? false;
-            return boolValue ? (useHidden ? Visibility.Hidden : Visibility.Collapsed) : Visibility.Visible;
-        }
-        return Visibility.Visible;
-    }
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b ? !b : (object) true;
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is Visibility visibility)
-        {
-            return visibility != Visibility.Visible;
-        }
-        return true;
-    }
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b ? !b : (object?) null;
 }

--- a/FModel/Views/Resources/Converters/InvertBooleanConverter.cs
+++ b/FModel/Views/Resources/Converters/InvertBooleanConverter.cs
@@ -8,7 +8,7 @@ public class InvertBooleanConverter : IValueConverter
 {
     public static readonly InvertBooleanConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is bool boolean)
         {
@@ -17,6 +17,6 @@ public class InvertBooleanConverter : IValueConverter
         return value;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is bool b ? !b : value;
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b ? !b : (object?) value;
 }

--- a/FModel/Views/Resources/Converters/InvertBooleanConverter.cs
+++ b/FModel/Views/Resources/Converters/InvertBooleanConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/IsNullToBoolReversedConverter.cs
+++ b/FModel/Views/Resources/Converters/IsNullToBoolReversedConverter.cs
@@ -8,12 +8,12 @@ public class IsNullToBoolReversedConverter : IValueConverter
 {
     public static readonly IsNullToBoolReversedConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         return value != null;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/IsNullToBoolReversedConverter.cs
+++ b/FModel/Views/Resources/Converters/IsNullToBoolReversedConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/RatioConverter.cs
+++ b/FModel/Views/Resources/Converters/RatioConverter.cs
@@ -1,27 +1,19 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
-using System.Windows.Markup;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
-public class RatioConverter : MarkupExtension, IValueConverter
+public class RatioConverter : IValueConverter
 {
-    private static readonly RatioConverter _instance = new();
+    public static readonly RatioConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var size = System.Convert.ToDouble(value) * System.Convert.ToDouble(parameter, culture);
         return size.ToString("G0", culture);
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
-
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        return _instance;
-    }
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/FModel/Views/Resources/Converters/RatioToGridLengthConverter.cs
+++ b/FModel/Views/Resources/Converters/RatioToGridLengthConverter.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Data;
+using Avalonia;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -9,9 +10,9 @@ public class RatioToGridLengthConverter : IMultiValueConverter
 {
     public static readonly RatioToGridLengthConverter Instance = new();
 
-    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values.Length < 2)
+        if (values.Count < 2)
             return new GridLength(1, GridUnitType.Star);
 
         var count1 = values[0] is int c1 ? c1 : 0;
@@ -20,13 +21,8 @@ public class RatioToGridLengthConverter : IMultiValueConverter
         var total = count1 + count2;
         if (total == 0) return new GridLength(1, GridUnitType.Star);
 
-        var ratio = (double)count1 / total;
+        var ratio = (double) count1 / total;
         return new GridLength(ratio, GridUnitType.Star);
-    }
-
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
     }
 }
 

--- a/FModel/Views/Resources/Converters/RelativeDateTimeConverter.cs
+++ b/FModel/Views/Resources/Converters/RelativeDateTimeConverter.cs
@@ -8,7 +8,7 @@ public class RelativeDateTimeConverter : IValueConverter
 {
     public static readonly RelativeDateTimeConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is DateTime dateTime)
         {
@@ -58,7 +58,7 @@ public class RelativeDateTimeConverter : IValueConverter
         return value;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/RelativeDateTimeConverter.cs
+++ b/FModel/Views/Resources/Converters/RelativeDateTimeConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/StatusToTaskbarStateConverter.cs
+++ b/FModel/Views/Resources/Converters/StatusToTaskbarStateConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Data.Converters;
 
@@ -10,13 +9,16 @@ namespace FModel.Views.Resources.Converters;
 /// Returns null; actual taskbar integration is tracked by TODO(P2-015).
 /// Previously mapped EStatusKind to System.Windows.Shell.TaskbarItemProgressState.
 /// </summary>
-public class StatusToTaskbarStateConverter : IMultiValueConverter
+public class StatusToTaskbarStateConverter : IValueConverter
 {
     public static readonly StatusToTaskbarStateConverter Instance = new();
 
-    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         // TODO(P2-015): Implement via Avalonia taskbar API when available.
         return null;
     }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/FModel/Views/Resources/Converters/StatusToTaskbarStateConverter.cs
+++ b/FModel/Views/Resources/Converters/StatusToTaskbarStateConverter.cs
@@ -1,31 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Windows.Data;
-using System.Windows.Markup;
-using System.Windows.Shell;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
-public class StatusToTaskbarStateConverter : MarkupExtension, IMultiValueConverter
+/// <summary>
+/// Stub: Avalonia has no cross-platform TaskbarItemProgressState equivalent.
+/// Returns null; actual taskbar integration is tracked by TODO(P2-015).
+/// Previously mapped EStatusKind to System.Windows.Shell.TaskbarItemProgressState.
+/// </summary>
+public class StatusToTaskbarStateConverter : IMultiValueConverter
 {
-    private static readonly StatusToTaskbarStateConverter _instance = new();
+    public static readonly StatusToTaskbarStateConverter Instance = new();
 
-    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values.Length != 2 || values[1] is true || values[0] is not EStatusKind kind)
-            return TaskbarItemProgressState.None;
-
-        return kind switch
-        {
-            EStatusKind.Loading => TaskbarItemProgressState.Normal,
-            EStatusKind.Stopping => TaskbarItemProgressState.Paused,
-            EStatusKind.Failed => TaskbarItemProgressState.Error,
-            _ => TaskbarItemProgressState.None,
-        };
+        // TODO(P2-015): Implement via Avalonia taskbar API when available.
+        return null;
     }
-
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-
-    public override object ProvideValue(IServiceProvider serviceProvider) => _instance;
 }

--- a/FModel/Views/Resources/Converters/StringToGameConverter.cs
+++ b/FModel/Views/Resources/Converters/StringToGameConverter.cs
@@ -8,7 +8,7 @@ public class StringToGameConverter : IValueConverter
 {
     public static readonly StringToGameConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         return value switch
         {
@@ -30,7 +30,7 @@ public class StringToGameConverter : IValueConverter
         };
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/StringToGameConverter.cs
+++ b/FModel/Views/Resources/Converters/StringToGameConverter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
-using FModel.Extensions;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 

--- a/FModel/Views/Resources/Converters/TabSizeConverter.cs
+++ b/FModel/Views/Resources/Converters/TabSizeConverter.cs
@@ -17,9 +17,11 @@ public class TabSizeConverter : IMultiValueConverter
 
         // Avalonia uses Bounds.Width instead of WPF's ActualWidth.
         var hasDivider = parameter is string;
-        var width = tabControl.Bounds.Width / (hasDivider
-            ? double.Parse(parameter!.ToString() ?? "6")
-            : tabControl.ItemCount);
+        double divisor = hasDivider
+            ? double.Parse(parameter!.ToString()!, CultureInfo.InvariantCulture)
+            : tabControl.ItemCount;
+        if (divisor <= 0) return 0;
+        var width = tabControl.Bounds.Width / divisor;
         return width <= 1 ? 0 : width - (hasDivider ? 8 : 0);
     }
 }

--- a/FModel/Views/Resources/Converters/TabSizeConverter.cs
+++ b/FModel/Views/Resources/Converters/TabSizeConverter.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Windows.Controls;
-using System.Windows.Data;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 
@@ -9,18 +10,16 @@ public class TabSizeConverter : IMultiValueConverter
 {
     public static readonly TabSizeConverter Instance = new();
 
-    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values[0] is not TabControl tabControl)
+        if (values.Count == 0 || values[0] is not TabControl tabControl)
             return 0;
 
+        // Avalonia uses Bounds.Width instead of WPF's ActualWidth.
         var hasDivider = parameter is string;
-        var width = tabControl.ActualWidth / (hasDivider ? double.Parse(parameter.ToString() ?? "6") : tabControl.Items.Count);
+        var width = tabControl.Bounds.Width / (hasDivider
+            ? double.Parse(parameter!.ToString() ?? "6")
+            : tabControl.ItemCount);
         return width <= 1 ? 0 : width - (hasDivider ? 8 : 0);
-    }
-
-    public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/FModel/Views/Resources/Converters/TrimRightToLeftConverter.cs
+++ b/FModel/Views/Resources/Converters/TrimRightToLeftConverter.cs
@@ -8,7 +8,7 @@ public class TrimRightToLeftConverter : IValueConverter
 {
     public static readonly TrimRightToLeftConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value == null) return null;
 
@@ -25,7 +25,7 @@ public class TrimRightToLeftConverter : IValueConverter
         return did ? $"...{path}" : path;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
     }

--- a/FModel/Views/Resources/Converters/TrimRightToLeftConverter.cs
+++ b/FModel/Views/Resources/Converters/TrimRightToLeftConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using System.Windows.Data;
+using Avalonia.Data.Converters;
 
 namespace FModel.Views.Resources.Converters;
 


### PR DESCRIPTION
## Summary

Closes #17.

Migrates every file in `FModel/Views/Resources/Converters/` off WPF's `System.Windows.Data` / `System.Windows.Markup` / `System.Windows.Shell` and onto Avalonia equivalents. 19 files changed; 7 were already migrated in a prior session.

> **Note:** This branch is based on `phase2/migrate-view-windows` and should be merged after PR #70.

---

## Changes by file

### Simple `using` swap only (interface signature already compatible)

| File | Change |
|---|---|
| `AnyItemMeetsConditionConverter` | `System.Windows.Data` → `Avalonia.Data.Converters` |
| `CommitMessageConverter` | same |
| `DateTimeToDateConverter` | same |
| `FolderToSeparatorTagConverter` | same |
| `GameFileMeetsConditionConverter` | same |
| `InvertBooleanConverter` | same |
| `IsNullToBoolReversedConverter` | same |
| `RelativeDateTimeConverter` | same |
| `StringToGameConverter` | same (also removed unused `FModel.Extensions` import) |
| `TrimRightToLeftConverter` | same |

### Structural changes

**`BoolToRenderModeConverter`**  
`BitmapScalingMode` (WPF) → `BitmapInterpolationMode` (Avalonia.Media.Imaging).  
Mapping: `NearestNeighbor` → `None`, `Linear` → `HighQuality`. Typed helper method return type updated accordingly.

**`BorderThicknessToStrokeThicknessConverter`**  
`System.Windows.Thickness` → `Avalonia.Thickness`. Same four-sided properties, no logic change.

**`InvertBoolToVisibilityConverter`**  
WPF `Visibility` enum replaced by `bool`. Avalonia uses `IsVisible` (bool), so `Collapsed`/`Hidden` both map to `false`. The `Hidden` parameter concept is dropped. XAML callers must bind to `IsVisible` instead of `Visibility`.

**`RatioConverter`**  
`System.Windows.Markup.MarkupExtension` removed (lives in `PresentationCore` — Windows-only).  
Added `public static readonly RatioConverter Instance = new()`. Update XAML from `{converters:RatioConverter 0.5}` to `{x:Static converters:RatioConverter.Instance}` + `ConverterParameter=0.5` in a subsequent phase.

**`RatioToGridLengthConverter`**  
`System.Windows.GridLength`/`GridUnitType` → `Avalonia.GridLength`/`GridUnitType`.  
Avalonia `IMultiValueConverter`: `Convert(IList<object?> values, ...)` (no `ConvertBack`).

**`StatusToTaskbarStateConverter`**  
Stubbed — `System.Windows.Shell.TaskbarItemProgressState` has no cross-platform Avalonia equivalent. Returns `null`. Tracked by `TODO(P2-015)`.  
`MarkupExtension` removed; `Instance` singleton added.

**`TabSizeConverter`**  
`System.Windows.Controls.TabControl` → `Avalonia.Controls.TabControl`.  
`ActualWidth` → `Bounds.Width`; `Items.Count` → `ItemCount`.  
Avalonia `IMultiValueConverter` signature applied.

**`FileToGeometryConverter`**  
`System.Windows.Media.Geometry` → `Avalonia.Media.Geometry`; `Brush` → `IBrush`.  
`Application.Current.FindResource(key)` → `Application.Current!.TryGetResource(key, null, out var r)`.  
Avalonia `IMultiValueConverter` signature applied.

**`FolderToGeometryConverter`**  
Same `Geometry`/`IBrush`/`TryGetResource` changes as above (remains `IValueConverter`).

### No changes needed (already migrated)

`BoolToToggleConverter`, `CaseInsensitiveStringEqualsConverter`, `EndpointToTypeConverter`, `EnumToStringConverter`, `IsNotZeroConverter`, `MultiParameterConverter`, `SizeToStringConverter`

---

## Build impact

| | Errors |
|---|---|
| Baseline (`phase2/migrate-view-windows`) | 1 266 |
| This branch | 1 174 |
| **Delta** | **−92** |

Zero new errors introduced in `Converters/`.

---

## Out of scope / deferred

- **P2-015** — `StatusToTaskbarStateConverter` stub: implement via Avalonia taskbar API (native interop) once the API surface is determined.
- XAML sites that use `{converters:RatioConverter …}` markup-extension syntax will need updating (next migration phase covers XAML files).
