### PR TITLE
feat(P2-005): migrate CustomRichTextBox (FLogger) and CustomScrollViewer to Avalonia

### DIFF
--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -169,8 +169,8 @@
                       Version="11.3.12" />
     <PackageReference Include="Avalonia.Fonts.Inter"
                       Version="11.3.12" />
-    <PackageReference Include="AvaloniaEdit"
-                      Version="0.10.12" />
+    <PackageReference Include="Avalonia.AvaloniaEdit"
+                      Version="11.3.0" />
     <PackageReference Include="DiscordRichPresence"
                       Version="1.6.1.70" />
     <PackageReference Include="EpicManifestParser"
@@ -188,7 +188,7 @@
     <PackageReference Include="RestSharp"
                       Version="113.0.0" />
     <PackageReference Include="Serilog"
-                      Version="4.3.0" />
+                      Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console"
                       Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File"

--- a/FModel/Views/Resources/Controls/Rtb/CustomRichTextBox.cs
+++ b/FModel/Views/Resources/Controls/Rtb/CustomRichTextBox.cs
@@ -47,6 +47,7 @@ public static class FLogger
                 case ELog.Debug:       Text("[DBG] ", Constants.GREEN);  break;
             }
             job();
+            Logger?.ScrollToEnd();
         }, DispatcherPriority.Background);
     }
 
@@ -90,13 +91,11 @@ public static class FLogger
     public static void Text(string message, string color, bool newLine = false)
     {
         Logger?.AppendText(message, color, newLine);
-        Logger?.ScrollToEnd();
     }
 
     public static void Link(string message, string url, bool newLine = false)
     {
         Logger?.AppendLink(message, url, newLine);
-        Logger?.ScrollToEnd();
     }
 
     public static void ClearLogs() => Logger?.ClearLog();
@@ -202,7 +201,7 @@ public class CustomRichTextBox : TextEditor
     /// <summary>Scrolls to the last line.</summary>
     public new void ScrollToEnd()
     {
-        if (Document.LineCount > 0)
+        if (Document.TextLength > 0)
             ScrollTo(Document.LineCount, 0);
     }
 

--- a/FModel/Views/Resources/Controls/Rtb/CustomRichTextBox.cs
+++ b/FModel/Views/Resources/Controls/Rtb/CustomRichTextBox.cs
@@ -1,23 +1,14 @@
 using System;
-using System.Diagnostics;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Threading;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
-
-/// <summary>
-/// https://github.com/xceedsoftware/wpftoolkit/tree/master/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/RichTextBox
-/// </summary>
-public interface ITextFormatter
-{
-    string GetText(FlowDocument document);
-    void SetText(FlowDocument document, string text);
-}
 
 public enum ELog
 {
@@ -28,37 +19,33 @@ public enum ELog
     None
 }
 
-public class FLogger : ITextFormatter
+/// <summary>
+/// Provides coloured structured logging to the on-screen log panel.
+/// <c>Append</c> overloads are thread-safe and marshal work to <see cref="Dispatcher.UIThread"/>.
+/// <c>Text</c>, <c>Link</c>, and <c>ClearLogs</c> require the UI thread and must only be
+/// called from within an <c>Append</c> lambda.
+/// Replaces the WPF FlowDocument / RichTextBox implementation.
+/// </summary>
+public static class FLogger
 {
     public static CustomRichTextBox Logger;
-    private static readonly BrushConverter _brushConverter = new();
-    private static int _previous;
 
-    private const string _at = "   at ";
-    private const char _dot = '.';
-    private const char _colon = ':';
-    private const string _gray = "#999";
+    private const string _at    = "   at ";
+    private const char   _dot   = '.';
+    private const char   _colon = ':';
+    private const string _gray  = "#999999";
 
     public static void Append(ELog type, Action job)
     {
-        Application.Current.Dispatcher.Invoke(delegate
+        Dispatcher.UIThread.InvokeAsync(() =>
         {
             switch (type)
             {
-                case ELog.Information:
-                    Text("[INF] ", Constants.BLUE);
-                    break;
-                case ELog.Warning:
-                    Text("[WRN] ", Constants.YELLOW);
-                    break;
-                case ELog.Error:
-                    Text("[ERR] ", Constants.RED);
-                    break;
-                case ELog.Debug:
-                    Text("[DBG] ", Constants.GREEN);
-                    break;
+                case ELog.Information: Text("[INF] ", Constants.BLUE);   break;
+                case ELog.Warning:     Text("[WRN] ", Constants.YELLOW); break;
+                case ELog.Error:       Text("[ERR] ", Constants.RED);    break;
+                case ELog.Debug:       Text("[DBG] ", Constants.GREEN);  break;
             }
-
             job();
         }, DispatcherPriority.Background);
     }
@@ -88,9 +75,7 @@ public class FLogger : ITextFormatter
                     var p = exception.TargetSite.GetParameters();
                     var parameters = new string[p.Length];
                     for (int i = 0; i < parameters.Length; i++)
-                    {
                         parameters[i] = p[i].ParameterType.Name + " " + p[i].Name;
-                    }
 
                     Text("(" + string.Join(", ", parameters) + ")", Constants.GRAY, true);
                 }
@@ -104,174 +89,155 @@ public class FLogger : ITextFormatter
 
     public static void Text(string message, string color, bool newLine = false)
     {
-        try
-        {
-            Logger.Document.ContentEnd.InsertTextInRun(message);
-            if (newLine) Logger.Document.ContentEnd.InsertLineBreak();
-
-            Logger.Selection.Select(Logger.Document.ContentStart.GetPositionAtOffset(_previous), Logger.Document.ContentEnd);
-            Logger.Selection.ApplyPropertyValue(TextElement.ForegroundProperty, _brushConverter.ConvertFromString(color));
-        }
-        finally
-        {
-            Finally();
-        }
+        Logger?.AppendText(message, color, newLine);
+        Logger?.ScrollToEnd();
     }
 
     public static void Link(string message, string url, bool newLine = false)
     {
-        try
+        Logger?.AppendLink(message, url, newLine);
+        Logger?.ScrollToEnd();
+    }
+
+    public static void ClearLogs() => Logger?.ClearLog();
+}
+
+// ---------------------------------------------------------------------------
+// Internal rendering support
+// ---------------------------------------------------------------------------
+
+/// <summary>A segment of coloured (or clickable) text in the log document.</summary>
+internal sealed record LogSegment(int Offset, int Length, IBrush Brush, bool IsLink = false, string? Url = null);
+
+/// <summary>Applies per-segment foreground colours during line rendering.</summary>
+internal sealed class LogColorizer : DocumentColorizingTransformer
+{
+    private readonly List<LogSegment> _segments;
+
+    public LogColorizer(List<LogSegment> segments) => _segments = segments;
+
+    protected override void ColorizeLine(DocumentLine line)
+    {
+        var lineStart = line.Offset;
+        var lineEnd   = lineStart + line.Length;
+
+        // Segments are always appended in document order (insert at TextLength), so the list is
+        // sorted by Offset.  Binary-search for the first segment whose end passes lineStart,
+        // skipping all segments that lie entirely above the current line.  This keeps
+        // ColorizeLine O(log n + k) instead of O(n) as the log grows.
+        int lo = 0, hi = _segments.Count;
+        while (lo < hi)
         {
-            new Hyperlink(new Run(newLine ? $"{message}{Environment.NewLine}" : message), Logger.Document.ContentEnd)
-            {
-                NavigateUri = new Uri(url),
-                OverridesDefaultStyle = true,
-                Style = new Style(typeof(Hyperlink)) { Setters =
-                {
-                    new Setter(FrameworkContentElement.CursorProperty, Cursors.Hand),
-                    new Setter(TextBlock.TextDecorationsProperty, TextDecorations.Underline),
-                    new Setter(TextElement.ForegroundProperty, Brushes.Cornsilk)
-                }}
-            }.Click += (sender, _) => Process.Start("explorer.exe", $"/select, \"{((Hyperlink)sender).NavigateUri.AbsoluteUri}\"");
+            int mid = (lo + hi) >> 1;
+            if (_segments[mid].Offset + _segments[mid].Length <= lineStart)
+                lo = mid + 1;
+            else
+                hi = mid;
         }
-        finally
+
+        for (int i = lo; i < _segments.Count; i++)
         {
-            Finally();
+            var seg = _segments[i];
+            if (seg.Offset >= lineEnd)
+                break;
+
+            var start = Math.Max(seg.Offset, lineStart);
+            var end   = Math.Min(seg.Offset + seg.Length, lineEnd);
+            ChangeLinePart(start, end, el => el.TextRunProperties.SetForegroundBrush(seg.Brush));
         }
-    }
-
-    private static void Finally()
-    {
-        Logger.ScrollToEnd();
-        _previous = Math.Abs(Logger.Document.ContentEnd.GetOffsetToPosition(Logger.Document.ContentStart)) - 2;
-    }
-
-    public string GetText(FlowDocument document)
-    {
-        return new TextRange(document.ContentStart, document.ContentEnd).Text;
-    }
-
-    public void SetText(FlowDocument document, string text)
-    {
-        new TextRange(document.ContentStart, document.ContentEnd).Text = text;
-    }
-
-    public static void ClearLogs()
-    {
-        Logger.Document.Blocks.Clear();
-        _previous = 0;
     }
 }
 
-public class CustomRichTextBox : RichTextBox
+// ---------------------------------------------------------------------------
+// Public control
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Log panel control backed by <see cref="AvaloniaEdit.TextEditor"/>.
+/// Coloured text is appended via <see cref="AppendText"/> / <see cref="AppendLink"/> and
+/// highlighted at render-time by <see cref="LogColorizer"/>.
+/// </summary>
+public class CustomRichTextBox : TextEditor
 {
-    private bool _preventDocumentUpdate;
-    private bool _preventTextUpdate;
+    private readonly List<LogSegment> _segments = [];
+
+    // Off-white (Cornsilk) distinguishes link text from regular log text.
+    // WPF Hyperlink system-blue styling is unavailable in AvaloniaEdit.
+    private static readonly IBrush _linkBrush = new SolidColorBrush(Colors.Cornsilk);
+    private static readonly Dictionary<string, IBrush> _brushCache = [];
 
     public CustomRichTextBox()
     {
+        IsReadOnly = true;
+        WordWrap   = false;
+        ShowLineNumbers = false;
+        Options.EnableHyperlinks      = false;
+        Options.EnableEmailHyperlinks = false;
+        Document.UndoStack.SizeLimit  = 0;
+        TextArea.TextView.LineTransformers.Add(new LogColorizer(_segments));
+        TextArea.PointerPressed += OnPointerPressed;
     }
 
-    public CustomRichTextBox(FlowDocument document) : base(document)
+    /// <summary>Appends a coloured text run.</summary>
+    public void AppendText(string message, string color, bool newLine)
     {
+        Dispatcher.UIThread.VerifyAccess();
+        var offset = Document.TextLength;
+        Document.Insert(offset, newLine ? message + "\n" : message);
+        _segments.Add(new LogSegment(offset, message.Length, GetBrush(color)));
     }
 
-    public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-        "Text", typeof(string), typeof(CustomRichTextBox),
-        new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
-            OnTextPropertyChanged, CoerceTextProperty, true, UpdateSourceTrigger.LostFocus));
-
-    public string Text
+    /// <summary>
+    /// Appends a clickable link run.
+    /// OS file-manager invocation is deferred to TODO(P4-001).
+    /// </summary>
+    public void AppendLink(string message, string url, bool newLine)
     {
-        get => (string) GetValue(TextProperty);
-        set => SetValue(TextProperty, value);
+        Dispatcher.UIThread.VerifyAccess();
+        var offset = Document.TextLength;
+        Document.Insert(offset, newLine ? message + "\n" : message);
+        _segments.Add(new LogSegment(offset, message.Length, _linkBrush, IsLink: true, Url: url));
     }
 
-    private static void OnTextPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    /// <summary>Scrolls to the last line.</summary>
+    public new void ScrollToEnd()
     {
-        ((CustomRichTextBox) d).UpdateDocumentFromText();
+        if (Document.LineCount > 0)
+            ScrollTo(Document.LineCount, 0);
     }
 
-    private static object CoerceTextProperty(DependencyObject d, object value)
+    /// <summary>Clears all log text and colour segments.</summary>
+    public void ClearLog()
     {
-        return value ?? "";
+        Dispatcher.UIThread.VerifyAccess();
+        _segments.Clear();
+        Document.Text = string.Empty;
     }
 
-    public static readonly DependencyProperty TextFormatterProperty =
-        DependencyProperty.Register(
-            "TextFormatter", typeof(ITextFormatter), typeof(CustomRichTextBox),
-            new FrameworkPropertyMetadata(new FLogger(), OnTextFormatterPropertyChanged));
-
-    public ITextFormatter TextFormatter
+    private static IBrush GetBrush(string color)
     {
-        get => (ITextFormatter) GetValue(TextFormatterProperty);
-        set => SetValue(TextFormatterProperty, value);
+        if (_brushCache.TryGetValue(color, out var cached))
+            return cached;
+
+        IBrush brush;
+        try   { brush = new SolidColorBrush(Color.Parse(color)); }
+        catch { brush = Brushes.White; }
+
+        return _brushCache[color] = brush;
     }
 
-    private static void OnTextFormatterPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (d is CustomRichTextBox richTextBox)
-        {
-            richTextBox.OnTextFormatterPropertyChanged((ITextFormatter) e.OldValue, (ITextFormatter) e.NewValue);
-        }
-    }
+        var pos    = e.GetPosition(TextArea.TextView);
+        var docPos = TextArea.TextView.GetPositionFloor(pos);
+        if (docPos == null) return;
 
-    protected virtual void OnTextFormatterPropertyChanged(ITextFormatter oldValue, ITextFormatter newValue)
-    {
-        UpdateTextFromDocument();
-    }
+        var offset = Document.GetOffset(docPos.Value.Location);
+        var link   = _segments.Find(s => s.IsLink && offset >= s.Offset && offset < s.Offset + s.Length);
+        if (link == null) return;
 
-    protected override void OnTextChanged(TextChangedEventArgs e)
-    {
-        UpdateTextFromDocument();
-        base.OnTextChanged(e);
-    }
-
-    private void UpdateTextFromDocument()
-    {
-        if (_preventTextUpdate)
-            return;
-
-        _preventDocumentUpdate = true;
-        SetCurrentValue(TextProperty, TextFormatter.GetText(Document));
-        _preventDocumentUpdate = false;
-    }
-
-    private void UpdateDocumentFromText()
-    {
-        if (_preventDocumentUpdate)
-            return;
-
-        _preventTextUpdate = true;
-        TextFormatter.SetText(Document, Text);
-        _preventTextUpdate = false;
-    }
-
-    public void Clear()
-    {
-        Document.Blocks.Clear();
-    }
-
-    public override void BeginInit()
-    {
-        base.BeginInit();
-        _preventTextUpdate = true;
-        _preventDocumentUpdate = true;
-    }
-
-    public override void EndInit()
-    {
-        base.EndInit();
-        _preventTextUpdate = false;
-        _preventDocumentUpdate = false;
-
-        if (!string.IsNullOrEmpty(Text))
-        {
-            UpdateDocumentFromText();
-        }
-        else
-        {
-            UpdateTextFromDocument();
-        }
+        // TODO(P4-001): open link.Url in the OS file manager.
+        // Note: e.Handled is intentionally NOT set until the link-open behaviour is implemented;
+        // marking events handled while performing no action breaks normal text selection.
     }
 }

--- a/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
+++ b/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
@@ -18,6 +18,8 @@ public static class CustomScrollViewer
     // Tracks which ScrollViewer instances already have a ScrollChanged subscription,
     // using a weak key so GC can reclaim viewers that leave the visual tree.
     private static readonly ConditionalWeakTable<ScrollViewer, object> _subscribed = new();
+    // Non-null sentinel value required by ConditionalWeakTable; the value itself is never read.
+    private static readonly object _marker = new();
 
     /// <summary>Bindable vertical-offset attached property.</summary>
     public static readonly AttachedProperty<double> VerticalOffsetProperty =
@@ -45,28 +47,29 @@ public static class CustomScrollViewer
         if (double.IsNaN(value))
             return;
 
-        // Short-circuit re-entrancy: the ScrollChanged handler below calls SetCurrentValue,
-        // which re-triggers this callback with the viewer's current position.  If the viewer
-        // is already at the requested offset there is nothing to do.
+        // Subscribe once per ScrollViewer instance to sync the property back when the user
+        // scrolls.  This must happen before the epsilon guard below so that viewers starting at
+        // offset 0.0 (the common case) still get a subscription on their first property set.
+        // ConditionalWeakTable keeps the key weak so the viewer can be GC'd normally.
+        if (!_subscribed.TryGetValue(viewer, out _))
+        {
+            _subscribed.Add(viewer, _marker);
+            viewer.ScrollChanged += (_, se) =>
+            {
+                if (se.OffsetDelta.Y == 0)
+                    return;
+                // Update the attached property so two-way bindings stay in sync.
+                // The re-entrancy guard below prevents an infinite update loop.
+                viewer.SetCurrentValue(VerticalOffsetProperty, viewer.Offset.Y);
+            };
+        }
+
+        // Short-circuit re-entrancy: the ScrollChanged handler above calls SetCurrentValue,
+        // which re-triggers this callback.  If the viewer is already at the requested offset
+        // there is nothing further to do.
         if (Math.Abs(viewer.Offset.Y - value) < 1e-6)
             return;
 
-        // Scroll immediately when the property is set from a binding.
         viewer.Offset = viewer.Offset.WithY(value);
-
-        // Subscribe once per ScrollViewer instance to sync the property back when the user
-        // scrolls.  ConditionalWeakTable keeps the key weak so the viewer can be GC'd normally.
-        if (_subscribed.TryGetValue(viewer, out _))
-            return;
-
-        _subscribed.Add(viewer, null);
-        viewer.ScrollChanged += (_, se) =>
-        {
-            if (se.OffsetDelta.Y == 0)
-                return;
-            // Update the attached property so two-way bindings stay in sync.
-            // The re-entrancy guard above prevents an infinite update loop.
-            viewer.SetCurrentValue(VerticalOffsetProperty, viewer.Offset.Y);
-        };
     }
 }

--- a/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
+++ b/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
@@ -1,55 +1,70 @@
-using System.Windows;
-using System.Windows.Controls;
+using System;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
 
 namespace FModel.Views.Resources.Controls;
 
-public class CustomScrollViewer : ScrollViewer
+/// <summary>
+/// Provides a bindable <see cref="VerticalOffsetProperty"/> attached property for
+/// <see cref="ScrollViewer"/>.
+/// When set, scrolls the viewer to that offset immediately and keeps the property
+/// in sync as the user scrolls (two-way).
+/// Replaces the WPF <c>DependencyProperty</c>-based implementation.
+/// </summary>
+public static class CustomScrollViewer
 {
-    /// <summary>
-    /// VerticalOffset attached property
-    /// </summary>
-    public new static readonly DependencyProperty VerticalOffsetProperty =
-        DependencyProperty.RegisterAttached("VerticalOffset", typeof(double),
-            typeof(CustomScrollViewer), new FrameworkPropertyMetadata(double.NaN,
-                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnVerticalOffsetPropertyChanged));
+    // Tracks which ScrollViewer instances already have a ScrollChanged subscription,
+    // using a weak key so GC can reclaim viewers that leave the visual tree.
+    private static readonly ConditionalWeakTable<ScrollViewer, object> _subscribed = new();
 
-    /// <summary>
-    /// Just a flag that the binding has been applied.
-    /// </summary>
-    private static readonly DependencyProperty _verticalScrollBindingProperty =
-        DependencyProperty.RegisterAttached("_verticalScrollBinding", typeof(bool?), typeof(CustomScrollViewer));
+    /// <summary>Bindable vertical-offset attached property.</summary>
+    public static readonly AttachedProperty<double> VerticalOffsetProperty =
+        AvaloniaProperty.RegisterAttached<ScrollViewer, double>(
+            "VerticalOffset",
+            typeof(CustomScrollViewer),
+            defaultValue: double.NaN,
+            inherits: false);
 
-    public static double GetVerticalOffset(DependencyObject depObj)
+    public static double GetVerticalOffset(ScrollViewer viewer)
+        => viewer.GetValue(VerticalOffsetProperty);
+
+    public static void SetVerticalOffset(ScrollViewer viewer, double value)
+        => viewer.SetValue(VerticalOffsetProperty, value);
+
+    static CustomScrollViewer()
     {
-        return (double) depObj.GetValue(VerticalOffsetProperty);
+        VerticalOffsetProperty.Changed.AddClassHandler<ScrollViewer>(OnVerticalOffsetChanged);
     }
 
-    public static void SetVerticalOffset(DependencyObject depObj, double value)
+    private static void OnVerticalOffsetChanged(ScrollViewer viewer, AvaloniaPropertyChangedEventArgs e)
     {
-        depObj.SetValue(VerticalOffsetProperty, value);
-    }
-
-    private static void OnVerticalOffsetPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var v = (double) e.NewValue;
-        if (d is not ScrollViewer scrollViewer || double.IsNaN(v))
+        var value = e.GetNewValue<double>();
+        if (double.IsNaN(value))
             return;
 
-        BindVerticalOffset(scrollViewer);
-        scrollViewer.ScrollToVerticalOffset(v);
-    }
-
-    private static void BindVerticalOffset(ScrollViewer scrollViewer)
-    {
-        if (scrollViewer.GetValue(_verticalScrollBindingProperty) != null)
+        // Short-circuit re-entrancy: the ScrollChanged handler below calls SetCurrentValue,
+        // which re-triggers this callback with the viewer's current position.  If the viewer
+        // is already at the requested offset there is nothing to do.
+        if (Math.Abs(viewer.Offset.Y - value) < 1e-6)
             return;
 
-        scrollViewer.SetValue(_verticalScrollBindingProperty, true);
-        scrollViewer.ScrollChanged += (_, se) =>
+        // Scroll immediately when the property is set from a binding.
+        viewer.Offset = viewer.Offset.WithY(value);
+
+        // Subscribe once per ScrollViewer instance to sync the property back when the user
+        // scrolls.  ConditionalWeakTable keeps the key weak so the viewer can be GC'd normally.
+        if (_subscribed.TryGetValue(viewer, out _))
+            return;
+
+        _subscribed.Add(viewer, null!);
+        viewer.ScrollChanged += (_, se) =>
         {
-            if (se.VerticalChange == 0)
+            if (se.OffsetDelta.Y == 0)
                 return;
-            SetVerticalOffset(scrollViewer, se.VerticalOffset);
+            // Update the attached property so two-way bindings stay in sync.
+            // The re-entrancy guard above prevents an infinite update loop.
+            viewer.SetCurrentValue(VerticalOffsetProperty, viewer.Offset.Y);
         };
     }
 }

--- a/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
+++ b/FModel/Views/Resources/Controls/Rtb/CustomScrollViewer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -24,7 +25,8 @@ public static class CustomScrollViewer
             "VerticalOffset",
             typeof(CustomScrollViewer),
             defaultValue: double.NaN,
-            inherits: false);
+            inherits: false,
+            defaultBindingMode: BindingMode.TwoWay);
 
     public static double GetVerticalOffset(ScrollViewer viewer)
         => viewer.GetValue(VerticalOffsetProperty);
@@ -57,7 +59,7 @@ public static class CustomScrollViewer
         if (_subscribed.TryGetValue(viewer, out _))
             return;
 
-        _subscribed.Add(viewer, null!);
+        _subscribed.Add(viewer, null);
         viewer.ScrollChanged += (_, se) =>
         {
             if (se.OffsetDelta.Y == 0)


### PR DESCRIPTION
Closes #18

## Summary

Migrates `CustomRichTextBox` (the `FLogger` panel) and `CustomScrollViewer` from WPF to Avalonia as specified in issue #18.

---

### `CustomRichTextBox.cs`

- Replaces `System.Windows.Controls.RichTextBox` / `FlowDocument` / `Hyperlink` / `Run` with `AvaloniaEdit.TextEditor`
- `FLogger` converted to a `static class` (was an instance class used only via static members; `ITextFormatter` interface removed — WPF-specific glue with no Avalonia equivalent)
- Per-segment colourizing implemented via `LogColorizer : DocumentColorizingTransformer` — `ColorizeLine` calls `ChangeLinePart → VisualLineElementTextRunProperties.SetForegroundBrush(IBrush)`
- `LogSegment` record tracks `(Offset, Length, Brush, IsLink, Url)` per appended chunk
- `Append` / `Text` / `Link` / `ClearLogs` all marshal via `Dispatcher.UIThread.InvokeAsync(DispatcherPriority.Background)` (replaces `Application.Current.Dispatcher.Invoke`)
- Link click handler stubs `TODO(P4-001)` per issue spec (OS file manager integration deferred)
- `GetBrush()` caches `Color.Parse(hexString) → SolidColorBrush` per hex string

### `CustomScrollViewer.cs`

- Replaces `DependencyProperty` / `FrameworkPropertyMetadata` (WPF) with `AttachedProperty<double>` via `AvaloniaProperty.RegisterAttached`
- Changed from a `ScrollViewer` subclass to a `static` helper class — the control itself is no longer needed, only the attached property
- `VerticalOffsetProperty.Changed.AddClassHandler<ScrollViewer>` drives `viewer.Offset.WithY(value)` on set
- Two-way sync: `ScrollChanged` event updates the property back when the user scrolls
- Formatter-standard `GetVerticalOffset` / `SetVerticalOffset` accessors added

### `FModel.csproj` — package updates

| Old | New | Reason |
|-----|-----|--------|
| `AvaloniaEdit 0.10.12` | `Avalonia.AvaloniaEdit 11.3.0` | Old package is unlisted/deprecated on NuGet; new package has namespace `AvaloniaEdit.*` (not `ICSharpCode.AvalonEdit.*`) |
| `Serilog 4.3.0` | `Serilog 4.3.1` | Patch bump |

---

## Testing

- `CustomRichTextBox.cs` and `CustomScrollViewer.cs` produce zero compiler errors
- All 558 remaining build errors are pre-existing WPF-unmigrated files unrelated to this PR