### PR TITLE
[P2-007] Migrate Magnifier adorner system to Avalonia

### DIFF
--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -36,7 +36,8 @@ namespace FModel.Settings
         private static bool _bSave = true;
         public static void Save()
         {
-            if (!_bSave || Default == null) return;
+            if (!_bSave || Default == null)
+                return;
             Default.PerDirectory[Default.CurrentDir.GameDirectory] = Default.CurrentDir;
             File.WriteAllText(FilePath, JsonConvert.SerializeObject(Default, Formatting.Indented));
         }
@@ -147,7 +148,7 @@ namespace FModel.Settings
             set => SetProperty(ref _isLoggerExpanded, value);
         }
 
-        private GridLength _avalonImageSize = new (200);
+        private GridLength _avalonImageSize = new(200);
         public GridLength AvalonImageSize
         {
             get => _avalonImageSize;
@@ -300,7 +301,7 @@ namespace FModel.Settings
             set => SetProperty(ref _manualGames, value);
         }
 
-        private AuthResponse _lastAuthResponse = new() {AccessToken = "", ExpiresAt = DateTime.Now};
+        private AuthResponse _lastAuthResponse = new() { AccessToken = "", ExpiresAt = DateTime.Now };
         public AuthResponse LastAuthResponse
         {
             get => _lastAuthResponse;

--- a/FModel/Views/Resources/Controls/ImagePopout.xaml
+++ b/FModel/Views/Resources/Controls/ImagePopout.xaml
@@ -1,6 +1,5 @@
 ﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:FModel.Views.Resources.Controls"
         x:Class="FModel.Views.Resources.Controls.ImagePopout"
         WindowStartupLocation="CenterScreen"
         Icon="{x:Null}">

--- a/FModel/Views/Resources/Controls/ImagePopout.xaml
+++ b/FModel/Views/Resources/Controls/ImagePopout.xaml
@@ -1,16 +1,15 @@
-﻿<adonisControls:AdonisWindow x:Class="FModel.Views.Resources.Controls.ImagePopout"
-         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:controls="clr-namespace:FModel.Views.Resources.Controls"
-         xmlns:adonisControls="clr-namespace:AdonisUI.Controls;assembly=AdonisUI"
-         WindowStartupLocation="CenterScreen" IconVisibility="Collapsed">
-    <DockPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-        <controls:MagnifierManager.Magnifier>
-            <controls:Magnifier Radius="150" ZoomFactor=".7" />
-        </controls:MagnifierManager.Magnifier>
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="using:FModel.Views.Resources.Controls"
+        x:Class="FModel.Views.Resources.Controls.ImagePopout"
+        WindowStartupLocation="CenterScreen"
+        Icon="{x:Null}">
+    <DockPanel x:Name="RootPanel"
+               HorizontalAlignment="Center" VerticalAlignment="Center">
 
-        <Border BorderBrush="#3b3d4a" BorderThickness="1" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Image x:Name="ImageCtrl" UseLayoutRounding="True" />
+        <Border BorderBrush="#3b3d4a" BorderThickness="1"
+                HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Image x:Name="ImageCtrl" />
         </Border>
     </DockPanel>
-</adonisControls:AdonisWindow>
+</Window>

--- a/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -15,10 +14,9 @@ public partial class ImagePopout : Window
     {
         base.OnAttachedToVisualTree(e);
 
-        var panel = this.FindControl<DockPanel>("RootPanel");
-        if (panel != null && MagnifierManager.GetMagnifier(panel) == null)
+        if (MagnifierManager.GetMagnifier(RootPanel) == null)
         {
-            MagnifierManager.SetMagnifier(panel, new Magnifier { Radius = 150, ZoomFactor = 0.7 });
+            MagnifierManager.SetMagnifier(RootPanel, new Magnifier { Radius = 150, ZoomFactor = 0.7 });
         }
     }
 }

--- a/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
@@ -1,9 +1,24 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
 namespace FModel.Views.Resources.Controls;
 
-public partial class ImagePopout
+public partial class ImagePopout : Window
 {
     public ImagePopout()
     {
         InitializeComponent();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        var panel = this.FindControl<DockPanel>("RootPanel");
+        if (panel != null && MagnifierManager.GetMagnifier(panel) == null)
+        {
+            MagnifierManager.SetMagnifier(panel, new Magnifier { Radius = 150, ZoomFactor = 0.7 });
+        }
     }
 }

--- a/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/ImagePopout.xaml.cs
@@ -1,4 +1,3 @@
-using Avalonia;
 using Avalonia.Controls;
 
 namespace FModel.Views.Resources.Controls;
@@ -8,15 +7,6 @@ public partial class ImagePopout : Window
     public ImagePopout()
     {
         InitializeComponent();
-    }
-
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        base.OnAttachedToVisualTree(e);
-
-        if (MagnifierManager.GetMagnifier(RootPanel) == null)
-        {
-            MagnifierManager.SetMagnifier(RootPanel, new Magnifier { Radius = 150, ZoomFactor = 0.7 });
-        }
+        MagnifierManager.SetMagnifier(RootPanel, new Magnifier { Radius = 150, ZoomFactor = 0.7 });
     }
 }

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -185,11 +185,16 @@ public class Magnifier : Control
 
     internal void UpdateViewBox()
     {
-        // Bounds.Width/Height are zero until the control is laid out.
-        if (Bounds.Width <= 0 || Bounds.Height <= 0)
+        // Prefer actual layout size; fall back to the Width/Height styled properties
+        // (default 100) so that ViewBox.Size is non-zero even before the first layout
+        // pass. This ensures CalculateViewBoxLocation() can center the viewport under
+        // the cursor on the very first PointerPressed before Bounds are measured.
+        var w = Bounds.Width > 0 ? Bounds.Width : Width;
+        var h = Bounds.Height > 0 ? Bounds.Height : Height;
+        if (w <= 0 || h <= 0)
             return;
 
-        ViewBox = new Rect(ViewBox.X, ViewBox.Y, Bounds.Width * ZoomFactor, Bounds.Height * ZoomFactor);
+        ViewBox = new Rect(ViewBox.X, ViewBox.Y, w * ZoomFactor, h * ZoomFactor);
         UpdateBrushViewBox();
         InvalidateVisual();
     }

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -115,8 +115,7 @@ public class Magnifier : Control
         {
             if (e.OldValue is Rect oldBounds && e.NewValue is Rect newBounds && oldBounds.Size == newBounds.Size)
                 return;
-            m.UpdateViewBox();
-            m.InvalidateVisual();
+            m.UpdateViewBox(); // UpdateViewBox already calls InvalidateVisual().
         });
     }
 

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Data;
 using Avalonia.Media;
 
 namespace FModel.Views.Resources.Controls;
@@ -80,17 +79,23 @@ public class Magnifier : TemplatedControl
         FrameTypeProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.OnFrameTypeChanged());
         RadiusProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.OnRadiusChanged());
         ZoomFactorProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.UpdateViewBox());
+        // Rebuild the VisualBrush whenever the Target control changes.
+        TargetProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.RebuildBrush());
 
         // Default Width / Height
         WidthProperty.OverrideDefaultValue<Magnifier>(DEFAULT_SIZE);
         HeightProperty.OverrideDefaultValue<Magnifier>(DEFAULT_SIZE);
+
+        // Class-level handler — must live in static ctor, not the instance ctor, to avoid
+        // registering N handlers for N instances (AddClassHandler is class-wide).
+        BoundsProperty.Changed.AddClassHandler<Magnifier>((m, _) =>
+        {
+            m.UpdateViewBox();
+            m.InvalidateVisual();
+        });
     }
 
-    public Magnifier()
-    {
-        // SizeChanged fires when Bounds change — update ViewBox accordingly.
-        BoundsProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.UpdateViewBox());
-    }
+    public Magnifier() { }
 
     // -----------------------------------------------------------------------
     // Overrides

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -1,139 +1,151 @@
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Media;
 
 namespace FModel.Views.Resources.Controls;
 
-[TemplatePart(Name = PART_VisualBrush, Type = typeof(VisualBrush))]
-public class Magnifier : Control
+public class Magnifier : TemplatedControl
 {
     private const double DEFAULT_SIZE = 100d;
-    private const string PART_VisualBrush = "PART_VisualBrush";
-    private VisualBrush _visualBrush = new();
 
-    public static readonly DependencyProperty FrameTypeProperty =
-        DependencyProperty.Register("FrameType", typeof(EFrameType), typeof(Magnifier), new UIPropertyMetadata(EFrameType.Circle, OnFrameTypeChanged));
+    // -----------------------------------------------------------------------
+    // Styled properties
+    // -----------------------------------------------------------------------
+
+    public static readonly StyledProperty<EFrameType> FrameTypeProperty =
+        AvaloniaProperty.Register<Magnifier, EFrameType>(nameof(FrameType), defaultValue: EFrameType.Circle);
     public EFrameType FrameType
     {
-        get => (EFrameType) GetValue(FrameTypeProperty);
+        get => GetValue(FrameTypeProperty);
         set => SetValue(FrameTypeProperty, value);
     }
 
-    private static void OnFrameTypeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var m = (Magnifier) d;
-        m.OnFrameTypeChanged((EFrameType) e.OldValue, (EFrameType) e.NewValue);
-    }
-
-    protected virtual void OnFrameTypeChanged(EFrameType oldValue, EFrameType newValue)
-    {
-        UpdateSizeFromRadius();
-    }
-
-    public static readonly DependencyProperty IsUsingZoomOnMouseWheelProperty =
-        DependencyProperty.Register("IsUsingZoomOnMouseWheel", typeof(bool), typeof(Magnifier), new UIPropertyMetadata(true));
+    public static readonly StyledProperty<bool> IsUsingZoomOnMouseWheelProperty =
+        AvaloniaProperty.Register<Magnifier, bool>(nameof(IsUsingZoomOnMouseWheel), defaultValue: true);
     public bool IsUsingZoomOnMouseWheel
     {
-        get => (bool) GetValue(IsUsingZoomOnMouseWheelProperty);
+        get => GetValue(IsUsingZoomOnMouseWheelProperty);
         set => SetValue(IsUsingZoomOnMouseWheelProperty, value);
     }
 
-    public bool IsFrozen { get; private set; }
-
-    public static readonly DependencyProperty RadiusProperty =
-        DependencyProperty.Register("Radius", typeof(double), typeof(Magnifier), new FrameworkPropertyMetadata(DEFAULT_SIZE / 2, OnRadiusPropertyChanged));
+    public static readonly StyledProperty<double> RadiusProperty =
+        AvaloniaProperty.Register<Magnifier, double>(nameof(Radius), defaultValue: DEFAULT_SIZE / 2);
     public double Radius
     {
-        get => (double) GetValue(RadiusProperty);
+        get => GetValue(RadiusProperty);
         set => SetValue(RadiusProperty, value);
     }
 
-    private static void OnRadiusPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    public static readonly StyledProperty<Control?> TargetProperty =
+        AvaloniaProperty.Register<Magnifier, Control?>(nameof(Target));
+    public Control? Target
     {
-        var m = (Magnifier) d;
-        m.OnRadiusChanged(e);
-    }
-
-    protected virtual void OnRadiusChanged(DependencyPropertyChangedEventArgs e)
-    {
-        UpdateSizeFromRadius();
-    }
-
-    public static readonly DependencyProperty TargetProperty = DependencyProperty.Register("Target", typeof(UIElement), typeof(Magnifier));
-    public UIElement Target
-    {
-        get => (UIElement) GetValue(TargetProperty);
+        get => GetValue(TargetProperty);
         set => SetValue(TargetProperty, value);
     }
 
-    public Rect ViewBox
-    {
-        get => _visualBrush.Viewbox;
-        set => _visualBrush.Viewbox = value;
-    }
-
-    public static readonly DependencyProperty ZoomFactorProperty =
-        DependencyProperty.Register("ZoomFactor", typeof(double), typeof(Magnifier), new FrameworkPropertyMetadata(0.5, OnZoomFactorPropertyChanged), OnValidationCallback);
+    public static readonly StyledProperty<double> ZoomFactorProperty =
+        AvaloniaProperty.Register<Magnifier, double>(nameof(ZoomFactor), defaultValue: 0.5,
+            validate: v => v >= 0);
     public double ZoomFactor
     {
-        get => (double) GetValue(ZoomFactorProperty);
+        get => GetValue(ZoomFactorProperty);
         set => SetValue(ZoomFactorProperty, value);
     }
 
-    private static bool OnValidationCallback(object baseValue)
-    {
-        return (double) baseValue >= 0;
-    }
-
-    private static void OnZoomFactorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var m = (Magnifier) d;
-        m.OnZoomFactorChanged(e);
-    }
-
-    protected virtual void OnZoomFactorChanged(DependencyPropertyChangedEventArgs e)
-    {
-        UpdateViewBox();
-    }
-
-    public static readonly DependencyProperty ZoomFactorOnMouseWheelProperty =
-        DependencyProperty.Register("ZoomFactorOnMouseWheel", typeof(double), typeof(Magnifier), new FrameworkPropertyMetadata(0.1d, OnZoomFactorOnMouseWheelPropertyChanged), OnZoomFactorOnMouseWheelValidationCallback);
+    public static readonly StyledProperty<double> ZoomFactorOnMouseWheelProperty =
+        AvaloniaProperty.Register<Magnifier, double>(nameof(ZoomFactorOnMouseWheel), defaultValue: 0.1d,
+            validate: v => v >= 0);
     public double ZoomFactorOnMouseWheel
     {
-        get => (double) GetValue(ZoomFactorOnMouseWheelProperty);
+        get => GetValue(ZoomFactorOnMouseWheelProperty);
         set => SetValue(ZoomFactorOnMouseWheelProperty, value);
     }
 
-    private static bool OnZoomFactorOnMouseWheelValidationCallback(object baseValue)
-    {
-        return (double) baseValue >= 0;
-    }
+    // ViewBox is not a styled property — it is driven programmatically by the adorner.
+    public Rect ViewBox { get; set; }
 
-    private static void OnZoomFactorOnMouseWheelPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var m = (Magnifier) d;
-        m.OnZoomFactorOnMouseWheelChanged(e);
-    }
+    public bool IsFrozen { get; private set; }
 
-    protected virtual void OnZoomFactorOnMouseWheelChanged(DependencyPropertyChangedEventArgs e)
-    {
-    }
+    // VisualBrush paints the magnified region; rebuilt whenever Target changes.
+    private VisualBrush? _visualBrush;
 
+    // -----------------------------------------------------------------------
+    // Static ctor — wire property-changed callbacks
+    // -----------------------------------------------------------------------
     static Magnifier()
     {
-        DefaultStyleKeyProperty.OverrideMetadata(typeof(Magnifier), new FrameworkPropertyMetadata(typeof(Magnifier)));
-        HeightProperty.OverrideMetadata(typeof(Magnifier), new FrameworkPropertyMetadata(DEFAULT_SIZE));
-        WidthProperty.OverrideMetadata(typeof(Magnifier), new FrameworkPropertyMetadata(DEFAULT_SIZE));
+        FrameTypeProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.OnFrameTypeChanged());
+        RadiusProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.OnRadiusChanged());
+        ZoomFactorProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.UpdateViewBox());
+
+        // Default Width / Height
+        WidthProperty.OverrideDefaultValue<Magnifier>(DEFAULT_SIZE);
+        HeightProperty.OverrideDefaultValue<Magnifier>(DEFAULT_SIZE);
     }
 
     public Magnifier()
     {
-        SizeChanged += OnSizeChangedEvent;
+        // SizeChanged fires when Bounds change — update ViewBox accordingly.
+        BoundsProperty.Changed.AddClassHandler<Magnifier>((m, _) => m.UpdateViewBox());
     }
 
-    private void OnSizeChangedEvent(object sender, SizeChangedEventArgs e)
+    // -----------------------------------------------------------------------
+    // Overrides
+    // -----------------------------------------------------------------------
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
+        base.OnApplyTemplate(e);
+        RebuildBrush();
         UpdateViewBox();
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        if (_visualBrush == null || Bounds.Width <= 0 || Bounds.Height <= 0)
+            return;
+
+        var strokeThickness = (BorderThickness.Left + BorderThickness.Top +
+                               BorderThickness.Right + BorderThickness.Bottom) / 4;
+        var pen = BorderBrush != null ? new Pen(BorderBrush, strokeThickness) : null;
+
+        if (FrameType == EFrameType.Circle)
+        {
+            var center = new Point(Bounds.Width / 2, Bounds.Height / 2);
+            var rx = Bounds.Width / 2;
+            var ry = Bounds.Height / 2;
+            if (Background != null)
+                context.DrawEllipse(Background, null, center, rx, ry);
+            context.DrawEllipse(_visualBrush, pen, center, rx, ry);
+        }
+        else
+        {
+            var rect = new Rect(0, 0, Bounds.Width, Bounds.Height);
+            if (Background != null)
+                context.DrawRectangle(Background, null, rect);
+            context.DrawRectangle(_visualBrush, pen, rect);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+    public void Freeze(bool freeze)
+    {
+        IsFrozen = freeze;
+    }
+
+    private void OnFrameTypeChanged()
+    {
+        UpdateSizeFromRadius();
+        InvalidateVisual();
+    }
+
+    private void OnRadiusChanged()
+    {
+        UpdateSizeFromRadius();
     }
 
     private void UpdateSizeFromRadius()
@@ -142,35 +154,48 @@ public class Magnifier : Control
 
         var newSize = Radius * 2;
         if (!Helper.AreVirtuallyEqual(Width, newSize))
-        {
             Width = newSize;
-        }
-
         if (!Helper.AreVirtuallyEqual(Height, newSize))
-        {
             Height = newSize;
-        }
     }
 
-    public override void OnApplyTemplate()
+    internal void UpdateViewBox()
     {
-        base.OnApplyTemplate();
-
-        var newBrush = GetTemplateChild(PART_VisualBrush) as VisualBrush ?? new VisualBrush();
-        newBrush.Viewbox = _visualBrush.Viewbox;
-        _visualBrush = newBrush;
-    }
-
-    public void Freeze(bool freeze)
-    {
-        IsFrozen = freeze;
-    }
-
-    private void UpdateViewBox()
-    {
-        if (!IsInitialized)
+        // Bounds.Width/Height are zero until the control is laid out.
+        if (Bounds.Width <= 0 || Bounds.Height <= 0)
             return;
 
-        ViewBox = new Rect(ViewBox.Location, new Size(ActualWidth * ZoomFactor, ActualHeight * ZoomFactor));
+        ViewBox = new Rect(ViewBox.X, ViewBox.Y, Bounds.Width * ZoomFactor, Bounds.Height * ZoomFactor);
+        UpdateBrushViewBox();
+        InvalidateVisual();
+    }
+
+    private void RebuildBrush()
+    {
+        if (Target == null)
+        {
+            _visualBrush = null;
+            InvalidateVisual();
+            return;
+        }
+
+        _visualBrush = new VisualBrush
+        {
+            SourceControl = Target,
+            Stretch = Stretch.None,
+            TileMode = TileMode.None,
+            AlignmentX = AlignmentX.Left,
+            AlignmentY = AlignmentY.Top,
+            DestinationRect = new RelativeRect(0, 0, 1, 1, RelativeUnit.Relative),
+        };
+        UpdateBrushViewBox();
+        InvalidateVisual();
+    }
+
+    private void UpdateBrushViewBox()
+    {
+        if (_visualBrush == null) return;
+        // SourceRect maps which region of Target is painted — the magnified "window".
+        _visualBrush.SourceRect = new RelativeRect(ViewBox, RelativeUnit.Absolute);
     }
 }

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -1,11 +1,10 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 
 namespace FModel.Views.Resources.Controls;
 
-public class Magnifier : TemplatedControl
+public class Magnifier : Control
 {
     private const double DEFAULT_SIZE = 100d;
 
@@ -63,6 +62,30 @@ public class Magnifier : TemplatedControl
         set => SetValue(ZoomFactorOnMouseWheelProperty, value);
     }
 
+    public static readonly StyledProperty<IBrush?> BackgroundProperty =
+        AvaloniaProperty.Register<Magnifier, IBrush?>(nameof(Background));
+    public IBrush? Background
+    {
+        get => GetValue(BackgroundProperty);
+        set => SetValue(BackgroundProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> BorderBrushProperty =
+        AvaloniaProperty.Register<Magnifier, IBrush?>(nameof(BorderBrush));
+    public IBrush? BorderBrush
+    {
+        get => GetValue(BorderBrushProperty);
+        set => SetValue(BorderBrushProperty, value);
+    }
+
+    public static readonly StyledProperty<Thickness> BorderThicknessProperty =
+        AvaloniaProperty.Register<Magnifier, Thickness>(nameof(BorderThickness));
+    public Thickness BorderThickness
+    {
+        get => GetValue(BorderThicknessProperty);
+        set => SetValue(BorderThicknessProperty, value);
+    }
+
     // ViewBox is not a styled property — it is driven programmatically by the adorner.
     public Rect ViewBox { get; set; }
 
@@ -88,8 +111,10 @@ public class Magnifier : TemplatedControl
 
         // Class-level handler — must live in static ctor, not the instance ctor, to avoid
         // registering N handlers for N instances (AddClassHandler is class-wide).
-        BoundsProperty.Changed.AddClassHandler<Magnifier>((m, _) =>
+        BoundsProperty.Changed.AddClassHandler<Magnifier>((m, e) =>
         {
+            if (e.OldValue is Rect oldBounds && e.NewValue is Rect newBounds && oldBounds.Size == newBounds.Size)
+                return;
             m.UpdateViewBox();
             m.InvalidateVisual();
         });
@@ -100,13 +125,6 @@ public class Magnifier : TemplatedControl
     // -----------------------------------------------------------------------
     // Overrides
     // -----------------------------------------------------------------------
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        base.OnApplyTemplate(e);
-        RebuildBrush();
-        UpdateViewBox();
-    }
-
     public override void Render(DrawingContext context)
     {
         if (_visualBrush == null || Bounds.Width <= 0 || Bounds.Height <= 0)
@@ -155,7 +173,8 @@ public class Magnifier : TemplatedControl
 
     private void UpdateSizeFromRadius()
     {
-        if (FrameType != EFrameType.Circle) return;
+        if (FrameType != EFrameType.Circle)
+            return;
 
         var newSize = Radius * 2;
         if (!Helper.AreVirtuallyEqual(Width, newSize))
@@ -187,7 +206,7 @@ public class Magnifier : TemplatedControl
         _visualBrush = new VisualBrush
         {
             SourceControl = Target,
-            Stretch = Stretch.None,
+            Stretch = Stretch.Fill,
             TileMode = TileMode.None,
             AlignmentX = AlignmentX.Left,
             AlignmentY = AlignmentY.Top,
@@ -199,7 +218,8 @@ public class Magnifier : TemplatedControl
 
     private void UpdateBrushViewBox()
     {
-        if (_visualBrush == null) return;
+        if (_visualBrush == null)
+            return;
         // SourceRect maps which region of Target is painted — the magnified "window".
         _visualBrush.SourceRect = new RelativeRect(ViewBox, RelativeUnit.Absolute);
     }

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
@@ -1,85 +1,96 @@
-using System.Windows;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
 
 namespace FModel.Views.Resources.Controls;
 
-public class MagnifierAdorner : Adorner
+/// <summary>
+/// Avalonia replacement for WPF MagnifierAdorner.
+/// Placed in the AdornerLayer as a Canvas that positions the <see cref="Magnifier"/> at the cursor.
+/// </summary>
+public class MagnifierAdorner : Canvas
 {
-    private Magnifier _magnifier;
-    private Point _currentMousePosition;
+    private readonly Control _adornedElement;
+    private readonly Magnifier _magnifier;
+    private Point _currentPointerPosition;
     private double _currentZoomFactor;
 
-    public MagnifierAdorner(UIElement element, Magnifier magnifier) : base(element)
+    public MagnifierAdorner(Control adornedElement, Magnifier magnifier)
     {
+        _adornedElement = adornedElement;
         _magnifier = magnifier;
-        _currentZoomFactor = _magnifier.ZoomFactor;
+        _currentZoomFactor = magnifier.ZoomFactor;
 
+        // The canvas must be transparent to hit-testing so pointer events reach the adorned control.
+        IsHitTestVisible = false;
+
+        Children.Add(_magnifier);
         UpdateViewBox();
-        AddVisualChild(_magnifier);
 
-        Loaded += (_, _) => InputManager.Current.PostProcessInput += OnProcessInput;
-        Unloaded += (_, _) => InputManager.Current.PostProcessInput -= OnProcessInput;
+        // Subscribe to pointer-move on the adorned element to track cursor position.
+        _adornedElement.PointerMoved += OnAdornedElementPointerMoved;
     }
 
-    private void OnProcessInput(object sender, ProcessInputEventArgs e)
+    public void Detach()
     {
-        var pt = Mouse.GetPosition(this);
-        if (_currentMousePosition == pt && _magnifier.ZoomFactor == _currentZoomFactor)
+        _adornedElement.PointerMoved -= OnAdornedElementPointerMoved;
+    }
+
+    private void OnAdornedElementPointerMoved(object? sender, PointerEventArgs e)
+    {
+        // Position relative to this adorner canvas (same coordinate space as the adorner layer).
+        var pt = e.GetPosition(this);
+
+        if (_currentPointerPosition == pt && _magnifier.ZoomFactor == _currentZoomFactor)
             return;
 
         if (_magnifier.IsFrozen)
             return;
 
-        _currentMousePosition = pt;
+        _currentPointerPosition = pt;
         _currentZoomFactor = _magnifier.ZoomFactor;
 
         UpdateViewBox();
-        InvalidateArrange();
+        PositionMagnifier();
     }
 
     public void UpdateViewBox()
     {
-        var viewBoxLocation = CalculateViewBoxLocation();
-        _magnifier.ViewBox = new Rect(viewBoxLocation, _magnifier.ViewBox.Size);
+        var location = CalculateViewBoxLocation();
+        _magnifier.ViewBox = new Rect(location, _magnifier.ViewBox.Size);
+        _magnifier.UpdateViewBox();
     }
 
     private Point CalculateViewBoxLocation()
     {
-        double offsetX, offsetY;
-        var adorner = Mouse.GetPosition(this);
-        var element = Mouse.GetPosition(AdornedElement);
+        // Position of the cursor relative to the adorner canvas.
+        var adornerPos = _currentPointerPosition;
+        // Position of the cursor relative to the adorned element.
+        var elementPos = _adornedElement.PointToClient(PointToScreen(adornerPos));
 
-        offsetX = element.X - adorner.X;
-        offsetY = element.Y - adorner.Y;
+        var offsetX = elementPos.X - adornerPos.X;
+        var offsetY = elementPos.Y - adornerPos.Y;
 
-        var parentOffsetVector = VisualTreeHelper.GetOffset(_magnifier.Target);
-        var parentOffset = new Point(parentOffsetVector.X, parentOffsetVector.Y);
+        // Account for the target control's offset within its parent coordinate space.
+        Point parentOffset = default;
+        if (_magnifier.Target != null)
+        {
+            var offsetVec = _magnifier.Target.TranslatePoint(default, _adornedElement);
+            if (offsetVec.HasValue)
+                parentOffset = offsetVec.Value;
+        }
 
-        var left = _currentMousePosition.X - (_magnifier.ViewBox.Width / 2 + offsetX) + parentOffset.X;
-        var top = _currentMousePosition.Y - (_magnifier.ViewBox.Height / 2 + offsetY) + parentOffset.Y;
+        var left = _currentPointerPosition.X - (_magnifier.ViewBox.Width / 2 + offsetX) + parentOffset.X;
+        var top  = _currentPointerPosition.Y - (_magnifier.ViewBox.Height / 2 + offsetY) + parentOffset.Y;
         return new Point(left, top);
     }
 
-    protected override Visual GetVisualChild(int index)
+    private void PositionMagnifier()
     {
-        return _magnifier;
-    }
-
-    protected override int VisualChildrenCount => 1;
-
-    protected override Size MeasureOverride(Size constraint)
-    {
-        _magnifier.Measure(constraint);
-        return base.MeasureOverride(constraint);
-    }
-
-    protected override Size ArrangeOverride(Size finalSize)
-    {
-        var x = _currentMousePosition.X - _magnifier.Width / 2;
-        var y = _currentMousePosition.Y - _magnifier.Height / 2;
-        _magnifier.Arrange(new Rect(x, y, _magnifier.Width, _magnifier.Height));
-        return base.ArrangeOverride(finalSize);
+        var x = _currentPointerPosition.X - _magnifier.Width / 2;
+        var y = _currentPointerPosition.Y - _magnifier.Height / 2;
+        SetLeft(_magnifier, x);
+        SetTop(_magnifier, y);
     }
 }

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
@@ -24,6 +24,9 @@ public class MagnifierAdorner : Canvas
 
         // The canvas must be transparent to hit-testing so pointer events reach the adorned control.
         IsHitTestVisible = false;
+        // Start hidden so the first ShowAdorner() call triggers IsVisible false→true,
+        // which fires OnPropertyChanged and subscribes PointerMoved correctly.
+        IsVisible = false;
 
         Children.Add(_magnifier);
         UpdateViewBox();

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
@@ -31,14 +31,26 @@ public class MagnifierAdorner : Canvas
         // Subscribe to pointer events on the adorned element.
         // PointerPressed fires first (manager handles ShowAdorner before this handler runs,
         // so the adorner is already in the visual tree when we call e.GetPosition(this)).
+        // PointerMoved is subscribed/unsubscribed dynamically via OnPropertyChanged(IsVisible).
         _adornedElement.PointerPressed += OnAdornedElementPointerPressed;
-        _adornedElement.PointerMoved   += OnAdornedElementPointerMoved;
     }
 
     public void Detach()
     {
         _adornedElement.PointerPressed -= OnAdornedElementPointerPressed;
-        _adornedElement.PointerMoved   -= OnAdornedElementPointerMoved;
+        _adornedElement.PointerMoved -= OnAdornedElementPointerMoved;
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == IsVisibleProperty)
+        {
+            if (change.GetNewValue<bool>())
+                _adornedElement.PointerMoved += OnAdornedElementPointerMoved;
+            else
+                _adornedElement.PointerMoved -= OnAdornedElementPointerMoved;
+        }
     }
 
     private void OnAdornedElementPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -92,7 +104,7 @@ public class MagnifierAdorner : Canvas
         }
 
         var left = _currentPointerPosition.X - (_magnifier.ViewBox.Width / 2 + offsetX) + parentOffset.X;
-        var top  = _currentPointerPosition.Y - (_magnifier.ViewBox.Height / 2 + offsetY) + parentOffset.Y;
+        var top = _currentPointerPosition.Y - (_magnifier.ViewBox.Height / 2 + offsetY) + parentOffset.Y;
         return new Point(left, top);
     }
 

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.VisualTree;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -14,6 +13,7 @@ public class MagnifierAdorner : Canvas
     private readonly Control _adornedElement;
     private readonly Magnifier _magnifier;
     private Point _currentPointerPosition;
+    private Point _currentElementPosition;
     private double _currentZoomFactor;
 
     public MagnifierAdorner(Control adornedElement, Magnifier magnifier)
@@ -28,18 +28,28 @@ public class MagnifierAdorner : Canvas
         Children.Add(_magnifier);
         UpdateViewBox();
 
-        // Subscribe to pointer-move on the adorned element to track cursor position.
-        _adornedElement.PointerMoved += OnAdornedElementPointerMoved;
+        // Subscribe to pointer events on the adorned element.
+        // PointerPressed fires first (manager handles ShowAdorner before this handler runs,
+        // so the adorner is already in the visual tree when we call e.GetPosition(this)).
+        _adornedElement.PointerPressed += OnAdornedElementPointerPressed;
+        _adornedElement.PointerMoved   += OnAdornedElementPointerMoved;
     }
 
     public void Detach()
     {
-        _adornedElement.PointerMoved -= OnAdornedElementPointerMoved;
+        _adornedElement.PointerPressed -= OnAdornedElementPointerPressed;
+        _adornedElement.PointerMoved   -= OnAdornedElementPointerMoved;
     }
 
+    private void OnAdornedElementPointerPressed(object? sender, PointerPressedEventArgs e)
+        => HandlePointerEvent(e);
+
     private void OnAdornedElementPointerMoved(object? sender, PointerEventArgs e)
+        => HandlePointerEvent(e);
+
+    private void HandlePointerEvent(PointerEventArgs e)
     {
-        // Position relative to this adorner canvas (same coordinate space as the adorner layer).
+        // Adorner-canvas-relative position (used for magnifier placement on the canvas).
         var pt = e.GetPosition(this);
 
         if (_currentPointerPosition == pt && _magnifier.ZoomFactor == _currentZoomFactor)
@@ -49,6 +59,8 @@ public class MagnifierAdorner : Canvas
             return;
 
         _currentPointerPosition = pt;
+        // Element-relative position (used for viewbox origin calculation — avoids PointToScreen round-trip).
+        _currentElementPosition = e.GetPosition(_adornedElement);
         _currentZoomFactor = _magnifier.ZoomFactor;
 
         UpdateViewBox();
@@ -64,13 +76,11 @@ public class MagnifierAdorner : Canvas
 
     private Point CalculateViewBoxLocation()
     {
-        // Position of the cursor relative to the adorner canvas.
-        var adornerPos = _currentPointerPosition;
-        // Position of the cursor relative to the adorned element.
-        var elementPos = _adornedElement.PointToClient(PointToScreen(adornerPos));
-
-        var offsetX = elementPos.X - adornerPos.X;
-        var offsetY = elementPos.Y - adornerPos.Y;
+        // offsetX/offsetY = coordinate delta between adorner-canvas space and adorned-element space.
+        // Both positions come from the same PointerEventArgs so they share the same root transform,
+        // making this DPI-safe without any PointToScreen / PointToClient round-trip.
+        var offsetX = _currentElementPosition.X - _currentPointerPosition.X;
+        var offsetY = _currentElementPosition.Y - _currentPointerPosition.Y;
 
         // Account for the target control's offset within its parent coordinate space.
         Point parentOffset = default;

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -77,9 +77,13 @@ public class MagnifierManager
             _element.PointerReleased -= ElementOnPointerReleased;
             _element.PointerWheelChanged -= ElementOnPointerWheelChanged;
             _element.DetachedFromVisualTree -= OnElementDetached;
+
+            // Remove the adorner control from the AdornerLayer so it is not left
+            // as an invisible orphan child for the lifetime of the host window.
+            var layer = AdornerLayer.GetAdornerLayer(_element);
+            layer?.SetAdornment(_element, null);
         }
         _adorner?.Detach();
-        HideAdorner();
         _adorner = null;
         _element = null;
     }

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -80,8 +80,8 @@ public class MagnifierManager
 
             // Remove the adorner control from the AdornerLayer so it is not left
             // as an invisible orphan child for the lifetime of the host window.
-            var layer = AdornerLayer.GetAdornerLayer(_element);
-            layer?.SetAdornment(_element, null);
+            // Use the static API to match the add path in VerifyAdornerLayer.
+            AdornerLayer.SetAdornment(_element, null);
         }
         _adorner?.Detach();
         _adorner = null;

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -1,78 +1,87 @@
 using System;
-using System.Windows;
-using System.Windows.Documents;
-using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Controls.Primitives;
 
 namespace FModel.Views.Resources.Controls;
 
-public class MagnifierManager : DependencyObject
+public class MagnifierManager
 {
-    private MagnifierAdorner _adorner;
-    private UIElement _element;
+    private MagnifierAdorner? _adorner;
+    private Control? _element;
 
-    public static readonly DependencyProperty CurrentProperty =
-        DependencyProperty.RegisterAttached("Magnifier", typeof(Magnifier), typeof(UIElement), new FrameworkPropertyMetadata(null, OnMagnifierChanged));
+    // -----------------------------------------------------------------------
+    // Attached property — usage: <Image controls:MagnifierManager.Magnifier="..." />
+    // -----------------------------------------------------------------------
+    public static readonly AttachedProperty<Magnifier?> MagnifierProperty =
+        AvaloniaProperty.RegisterAttached<MagnifierManager, Control, Magnifier?>("Magnifier");
 
-    public static void SetMagnifier(UIElement element, Magnifier value)
+    public static void SetMagnifier(Control element, Magnifier? value)
+        => element.SetValue(MagnifierProperty, value);
+
+    public static Magnifier? GetMagnifier(Control element)
+        => element.GetValue(MagnifierProperty);
+
+    static MagnifierManager()
     {
-        element.SetValue(CurrentProperty, value);
+        MagnifierProperty.Changed.Subscribe(OnMagnifierChanged);
     }
 
-    public static Magnifier GetMagnifier(UIElement element)
+    private static void OnMagnifierChanged(AvaloniaPropertyChangedEventArgs<Magnifier?> e)
     {
-        return (Magnifier) element.GetValue(CurrentProperty);
+        if (e.Sender is not Control target)
+            throw new ArgumentException("Magnifier can only be attached to a Control.");
+
+        if (e.NewValue.Value is { } magnifier)
+            new MagnifierManager().AttachToMagnifier(target, magnifier);
     }
 
-    private static void OnMagnifierChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    // -----------------------------------------------------------------------
+    // Instance — manages one control/magnifier pair
+    // -----------------------------------------------------------------------
+    private void ElementOnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        if (d is not UIElement target)
-            throw new ArgumentException("Magnifier can only be attached to a UIElement.");
-
-        new MagnifierManager().AttachToMagnifier(target, e.NewValue as Magnifier);
-    }
-
-    private void ElementOnMouseLeftButtonUp(object sender, MouseEventArgs e)
-    {
-        if (GetMagnifier(_element) is { IsFrozen: true })
+        if (_element != null && GetMagnifier(_element) is { IsFrozen: true })
             return;
 
         HideAdorner();
     }
 
-    private void ElementOnMouseLeftButtonDown(object sender, MouseEventArgs e)
+    private void ElementOnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         ShowAdorner();
     }
 
-    private void ElementOnMouseWheel(object sender, MouseWheelEventArgs e)
+    private void ElementOnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
+        if (_element == null) return;
         if (GetMagnifier(_element) is not { IsUsingZoomOnMouseWheel: true } magnifier) return;
 
-        switch (e.Delta)
+        // WPF Delta < 0 = scroll down = zoom out (larger viewbox); Delta > 0 = scroll up = zoom in.
+        // Avalonia Delta.Y > 0 = scroll up.
+        if (e.Delta.Y < 0)
         {
-            case < 0:
-            {
-                var newValue = magnifier.ZoomFactor + magnifier.ZoomFactorOnMouseWheel;
-                magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
-                break;
-            }
-            case > 0:
-            {
-                var newValue = magnifier.ZoomFactor >= magnifier.ZoomFactorOnMouseWheel ? magnifier.ZoomFactor - magnifier.ZoomFactorOnMouseWheel : 0d;
-                magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
-                break;
-            }
+            var newValue = magnifier.ZoomFactor + magnifier.ZoomFactorOnMouseWheel;
+            magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
+        }
+        else if (e.Delta.Y > 0)
+        {
+            var newValue = magnifier.ZoomFactor >= magnifier.ZoomFactorOnMouseWheel
+                ? magnifier.ZoomFactor - magnifier.ZoomFactorOnMouseWheel
+                : 0d;
+            magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
         }
 
-        _adorner.UpdateViewBox();
+        _adorner?.UpdateViewBox();
     }
 
-    private void AttachToMagnifier(UIElement element, Magnifier magnifier)
+    private void AttachToMagnifier(Control element, Magnifier magnifier)
     {
         _element = element;
-        _element.MouseLeftButtonDown += ElementOnMouseLeftButtonDown;
-        _element.MouseLeftButtonUp += ElementOnMouseLeftButtonUp;
-        _element.MouseWheel += ElementOnMouseWheel;
+        _element.PointerPressed  += ElementOnPointerPressed;
+        _element.PointerReleased += ElementOnPointerReleased;
+        _element.PointerWheelChanged += ElementOnPointerWheelChanged;
 
         magnifier.Target = _element;
 
@@ -81,22 +90,24 @@ public class MagnifierManager : DependencyObject
 
     private void ShowAdorner()
     {
+        if (_adorner == null || _element == null) return;
         VerifyAdornerLayer();
-        _adorner.Visibility = Visibility.Visible;
+        _adorner.IsVisible = true;
     }
 
     private void VerifyAdornerLayer()
     {
+        if (_adorner == null || _element == null) return;
         if (_adorner.Parent != null) return;
+
         var layer = AdornerLayer.GetAdornerLayer(_element);
-        layer?.Add(_adorner);
+        if (layer != null)
+            AdornerLayer.SetAdornment(_element, _adorner);
     }
 
     private void HideAdorner()
     {
-        if (_adorner.Visibility == Visibility.Visible)
-        {
-            _adorner.Visibility = Visibility.Collapsed;
-        }
+        if (_adorner is { IsVisible: true })
+            _adorner.IsVisible = false;
     }
 }

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -10,6 +11,9 @@ public class MagnifierManager
 {
     private MagnifierAdorner? _adorner;
     private Control? _element;
+
+    // Stores active managers so OnMagnifierChanged can detach the old one when the property changes.
+    private static readonly ConditionalWeakTable<Control, MagnifierManager> _managers = new();
 
     // -----------------------------------------------------------------------
     // Attached property — usage: <Image controls:MagnifierManager.Magnifier="..." />
@@ -33,13 +37,60 @@ public class MagnifierManager
         if (e.Sender is not Control target)
             throw new ArgumentException("Magnifier can only be attached to a Control.");
 
-        if (e.NewValue.Value is { } magnifier)
-            new MagnifierManager().AttachToMagnifier(target, magnifier);
+        // Detach any previously registered manager on this element before attaching a new one.
+        if (_managers.TryGetValue(target, out var old))
+        {
+            old.Detach();
+            _managers.Remove(target);
+        }
+
+        var magnifier = e.NewValue.GetValueOrDefault();
+        if (magnifier != null)
+        {
+            var manager = new MagnifierManager();
+            manager.AttachToMagnifier(target, magnifier);
+            _managers.Add(target, manager);
+        }
     }
 
     // -----------------------------------------------------------------------
     // Instance — manages one control/magnifier pair
     // -----------------------------------------------------------------------
+
+    private void AttachToMagnifier(Control element, Magnifier magnifier)
+    {
+        _element = element;
+        _element.PointerPressed  += ElementOnPointerPressed;
+        _element.PointerReleased += ElementOnPointerReleased;
+        _element.PointerWheelChanged += ElementOnPointerWheelChanged;
+        _element.DetachedFromVisualTree += OnElementDetached;
+
+        magnifier.Target = _element;
+
+        _adorner = new MagnifierAdorner(_element, magnifier);
+    }
+
+    private void Detach()
+    {
+        if (_element != null)
+        {
+            _element.PointerPressed  -= ElementOnPointerPressed;
+            _element.PointerReleased -= ElementOnPointerReleased;
+            _element.PointerWheelChanged -= ElementOnPointerWheelChanged;
+            _element.DetachedFromVisualTree -= OnElementDetached;
+        }
+        _adorner?.Detach();
+        HideAdorner();
+        _adorner = null;
+        _element = null;
+    }
+
+    private void OnElementDetached(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _adorner?.Detach();
+        HideAdorner();
+    }
+
     private void ElementOnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         if (_element != null && GetMagnifier(_element) is { IsFrozen: true })
@@ -74,18 +125,6 @@ public class MagnifierManager
         }
 
         _adorner?.UpdateViewBox();
-    }
-
-    private void AttachToMagnifier(Control element, Magnifier magnifier)
-    {
-        _element = element;
-        _element.PointerPressed  += ElementOnPointerPressed;
-        _element.PointerReleased += ElementOnPointerReleased;
-        _element.PointerWheelChanged += ElementOnPointerWheelChanged;
-
-        magnifier.Target = _element;
-
-        _adorner = new MagnifierAdorner(_element, magnifier);
     }
 
     private void ShowAdorner()

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -86,8 +86,12 @@ public class MagnifierManager
 
     private void OnElementDetached(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        _adorner?.Detach();
-        HideAdorner();
+        // Full teardown so that if the element is ever re-attached and SetMagnifier is
+        // called again, a fresh manager/adorner pair is created from scratch.
+        var element = _element;
+        Detach();
+        if (element != null)
+            _managers.Remove(element);
     }
 
     private void ElementOnPointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Controls.Primitives;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -60,7 +59,7 @@ public class MagnifierManager
     private void AttachToMagnifier(Control element, Magnifier magnifier)
     {
         _element = element;
-        _element.PointerPressed  += ElementOnPointerPressed;
+        _element.PointerPressed += ElementOnPointerPressed;
         _element.PointerReleased += ElementOnPointerReleased;
         _element.PointerWheelChanged += ElementOnPointerWheelChanged;
         _element.DetachedFromVisualTree += OnElementDetached;
@@ -74,7 +73,7 @@ public class MagnifierManager
     {
         if (_element != null)
         {
-            _element.PointerPressed  -= ElementOnPointerPressed;
+            _element.PointerPressed -= ElementOnPointerPressed;
             _element.PointerReleased -= ElementOnPointerReleased;
             _element.PointerWheelChanged -= ElementOnPointerWheelChanged;
             _element.DetachedFromVisualTree -= OnElementDetached;
@@ -93,6 +92,8 @@ public class MagnifierManager
 
     private void ElementOnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        if (e.GetCurrentPoint(null).Properties.PointerUpdateKind != PointerUpdateKind.LeftButtonReleased)
+            return;
         if (_element != null && GetMagnifier(_element) is { IsFrozen: true })
             return;
 
@@ -101,13 +102,16 @@ public class MagnifierManager
 
     private void ElementOnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        ShowAdorner();
+        if (e.GetCurrentPoint(null).Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
+            ShowAdorner();
     }
 
     private void ElementOnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        if (_element == null) return;
-        if (GetMagnifier(_element) is not { IsUsingZoomOnMouseWheel: true } magnifier) return;
+        if (_element == null)
+            return;
+        if (GetMagnifier(_element) is not { IsUsingZoomOnMouseWheel: true } magnifier)
+            return;
 
         // WPF Delta < 0 = scroll down = zoom out (larger viewbox); Delta > 0 = scroll up = zoom in.
         // Avalonia Delta.Y > 0 = scroll up.
@@ -129,15 +133,18 @@ public class MagnifierManager
 
     private void ShowAdorner()
     {
-        if (_adorner == null || _element == null) return;
+        if (_adorner == null || _element == null)
+            return;
         VerifyAdornerLayer();
         _adorner.IsVisible = true;
     }
 
     private void VerifyAdornerLayer()
     {
-        if (_adorner == null || _element == null) return;
-        if (_adorner.Parent != null) return;
+        if (_adorner == null || _element == null)
+            return;
+        if (_adorner.Parent != null)
+            return;
 
         var layer = AdornerLayer.GetAdornerLayer(_element);
         if (layer != null)


### PR DESCRIPTION
Closes #20

## Changes

### `Magnifier.cs`
- `System.Windows.Controls.Control` → Avalonia `TemplatedControl`
- `DependencyProperty` → `StyledProperty<T>` with `AddClassHandler` callbacks
- `Target` property type `UIElement` → `Control`
- Validation callbacks → `validate:` parameter on `Register`
- `OverrideMetadata` → `OverrideDefaultValue<T>`
- `SizeChanged` event → `BoundsProperty.Changed` class handler
- `IsInitialized` guard → `Bounds.Width/Height > 0` guard
- **Rendering approach change**: the WPF version relied on a `ControlTemplate` in `Resources.xaml` with a `VisualBrush` template part. Since `Resources.xaml` is not yet migrated to Avalonia, `Magnifier` now renders itself via `Render(DrawingContext)`. `DrawEllipse`/`DrawRectangle` are called directly with a `VisualBrush` whose `SourceControl` is the `Target` and `SourceRect` carries the magnified viewport (equivalent to WPF `VisualBrush.Viewbox` + `ViewboxUnits=Absolute`). The brush is rebuilt in `RebuildBrush()` whenever `Target` changes.

### `MagnifierAdorner.cs`
- WPF `Adorner` subclass → Avalonia `Canvas`-based adorner control placed via `AdornerLayer.SetAdornment`
- `AddVisualChild` / `ArrangeOverride` → `Canvas.Children` + `Canvas.SetLeft`/`SetTop`
- `InputManager.Current.PostProcessInput` → `PointerMoved` on the adorned element
- `VisualTreeHelper.GetOffset` → `Control.TranslatePoint`
- `Detach()` added for clean unsubscription

### `MagnifierManager.cs`
- `DependencyObject` + `RegisterAttached` → plain class with `AvaloniaProperty.RegisterAttached`; change handler wired via `MagnifierProperty.Changed.Subscribe`
- `MouseLeftButtonDown/Up` → `PointerPressed/Released`
- `MouseWheel` → `PointerWheelChanged`; sign convention preserved (`Delta.Y < 0` = scroll down = zoom out)
- `AdornerLayer.GetAdornerLayer` + `layer.Add` → `AdornerLayer.GetAdornerLayer` + `AdornerLayer.SetAdornment`
- `Visibility` → `IsVisible`

### `ImagePopout.xaml` / `.xaml.cs`
- `AdonisWindow` → Avalonia `Window`
- `MagnifierManager.Magnifier` inline object-element XAML syntax not supported in Avalonia for attached properties pointing to a different element; moved to `OnAttachedToVisualTree` in code-behind
- `UseLayoutRounding` removed (Avalonia default)
