### PR TITLE
feat(aup): migrate SpectrumAnalyzer and Timeline to Avalonia

### DIFF
--- a/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
+++ b/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
@@ -108,10 +108,8 @@ public sealed class SpectrumAnalyzer : UserControl
         FrequencyBarCountProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, e) =>
         {
             var nv = (int) e.NewValue!;
-            if (nv < 1)
-                m.FrequencyBarCount = 1;
-            else if (nv > 100)
-                m.FrequencyBarCount = 100;
+            if (nv < 1) { m.FrequencyBarCount = 1; return; }
+            if (nv > 100) { m.FrequencyBarCount = 100; return; }
             m.CreateBars();
         });
 
@@ -120,6 +118,7 @@ public sealed class SpectrumAnalyzer : UserControl
             if (e.OldValue is Rect old && e.NewValue is Rect nw && old.Size != nw.Size)
                 m.UpdateFrequencyMapping();
         });
+        FrequencyBarBorderThicknessProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, _) => m.CreateBars());
     }
 
     public SpectrumAnalyzer()
@@ -156,6 +155,7 @@ public sealed class SpectrumAnalyzer : UserControl
             return;
         _spectrumProvider = Source?.Spectrum;
         UpdateFrequencyMapping();
+        CreateBars();
     }
 
     private void OnSourcePropertyChangedEvent(object? sender, SourcePropertyChangedEventArgs e)
@@ -255,6 +255,8 @@ public sealed class SpectrumAnalyzer : UserControl
 
     private void UpdateSpectrum(double maxValue, IReadOnlyList<float> fftBuffer)
     {
+        if (_bars.Length == 0)
+            return;
         var spectrumScalingStrategy = ScalingStrategy.Decibel;
         Dispatcher.UIThread.Invoke(() => spectrumScalingStrategy = SpectrumScalingStrategy);
 

--- a/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
+++ b/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
@@ -108,8 +108,10 @@ public sealed class SpectrumAnalyzer : UserControl
         FrequencyBarCountProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, e) =>
         {
             var nv = (int) e.NewValue!;
-            if (nv < 1) { m.FrequencyBarCount = 1; return; }
-            if (nv > 100) { m.FrequencyBarCount = 100; return; }
+            if (nv < 1)
+            { m.FrequencyBarCount = 1; return; }
+            if (nv > 100)
+            { m.FrequencyBarCount = 100; return; }
             m.CreateBars();
         });
 
@@ -119,6 +121,9 @@ public sealed class SpectrumAnalyzer : UserControl
                 m.UpdateFrequencyMapping();
         });
         FrequencyBarBorderThicknessProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, _) => m.CreateBars());
+        FrequencyBarBrushProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, _) => m.CreateBars());
+        FrequencyBarBorderBrushProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, _) => m.CreateBars());
+        FrequencyBarCornerRadiusProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, _) => m.CreateBars());
     }
 
     public SpectrumAnalyzer()
@@ -226,7 +231,11 @@ public sealed class SpectrumAnalyzer : UserControl
 
     private void SilenceBars()
     {
-        Dispatcher.UIThread.Post(() => _spectrumGrid.Children.Clear(), DispatcherPriority.Render);
+        Dispatcher.UIThread.Post(() =>
+        {
+            _spectrumGrid.Children.Clear();
+            _bars = Array.Empty<Border>();
+        }, DispatcherPriority.Render);
     }
 
     private void UpdateFrequencyMapping()

--- a/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
+++ b/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
@@ -264,10 +264,13 @@ public sealed class SpectrumAnalyzer : UserControl
 
     private void UpdateSpectrum(double maxValue, IReadOnlyList<float> fftBuffer)
     {
-        if (_bars.Length == 0)
+        // Snapshot the array reference — SilenceBars() may replace _bars on the UI thread
+        // concurrently; the snapshot keeps the closure and the loop bound in sync.
+        var bars = _bars;
+        if (bars.Length == 0)
             return;
-        var spectrumScalingStrategy = ScalingStrategy.Decibel;
-        Dispatcher.UIThread.Invoke(() => spectrumScalingStrategy = SpectrumScalingStrategy);
+        // SpectrumScalingStrategy is a value-type StyledProperty — safe to read from any thread.
+        var spectrumScalingStrategy = SpectrumScalingStrategy;
 
         var lastValue = 0D;
         var spectrumPointIndex = 0;
@@ -305,15 +308,18 @@ public sealed class SpectrumAnalyzer : UserControl
 
         Dispatcher.UIThread.Post(() =>
         {
-            var barCount = Math.Min(FrequencyBarCount, dataPoints.Count);
+            // Use the snapshotted array as the authoritative bar count so that
+            // FrequencyBarCount changes or a concurrent SilenceBars() call cannot
+            // cause the loop to index past the end of the array.
+            var barCount = Math.Min(bars.Length, dataPoints.Count);
             for (var i = 0; i < barCount; i++)
             {
-                var barSpacing = Bounds.Width / FrequencyBarCount;
+                var barSpacing = Bounds.Width / bars.Length;
                 var barWidth = barSpacing - FrequencyBarSpacing;
                 if (barWidth < .5)
                     barWidth = .5;
 
-                var b = _bars[i];
+                var b = bars[i];
                 b.Height = dataPoints[i] / 100 * Bounds.Height;
                 b.Width = barWidth;
                 b.Margin = new Thickness(i * barSpacing, 0, 0, 0);

--- a/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
+++ b/FModel/Views/Resources/Controls/Aup/SpectrumAnalyzer.cs
@@ -1,16 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Threading;
-using CSCore;
-using CSCore.SoundIn;
-using CSCore.SoundOut;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Threading;
+// TODO(P3-013): CSCore.SoundIn not available on Linux — RecordingState will be replaced with cross-platform audio backend
+// using CSCore.SoundIn;
+// TODO(P3-013): CSCore.SoundOut not available on Linux — PlaybackState will be replaced with cross-platform audio backend
+// using CSCore.SoundOut;
 
 namespace FModel.Views.Resources.Controls.Aup;
 
-[TemplatePart(Name = "PART_Spectrum", Type = typeof(Grid))]
 public sealed class SpectrumAnalyzer : UserControl
 {
     public enum ScalingStrategy
@@ -20,301 +21,173 @@ public sealed class SpectrumAnalyzer : UserControl
         Sqrt
     }
 
-    private Grid _spectrumGrid;
-    private Border[] _bars;
+    private readonly Grid _spectrumGrid = new();
+    private Border[] _bars = Array.Empty<Border>();
 
-    static SpectrumAnalyzer()
+    // -----------------------------------------------------------------------
+    // Styled properties
+    // -----------------------------------------------------------------------
+
+    public static readonly StyledProperty<ISource?> SourceProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, ISource?>(nameof(Source));
+    public ISource? Source
     {
-        DefaultStyleKeyProperty.OverrideMetadata(typeof(SpectrumAnalyzer), new FrameworkPropertyMetadata(typeof(SpectrumAnalyzer)));
-    }
-
-    private ISource _source;
-
-    public ISource Source
-    {
-        get => (ISource) GetValue(SourceProperty);
+        get => GetValue(SourceProperty);
         set => SetValue(SourceProperty, value);
     }
 
-    public static readonly DependencyProperty SourceProperty =
-        DependencyProperty.Register("Source", typeof(ISource), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(null, OnSourceChanged, OnCoerceSource));
-
+    public static readonly StyledProperty<ScalingStrategy> ScalingStrategyProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, ScalingStrategy>(nameof(SpectrumScalingStrategy),
+            defaultValue: ScalingStrategy.Linear);
     public ScalingStrategy SpectrumScalingStrategy
     {
-        get => (ScalingStrategy) GetValue(ScalingStrategyProperty);
+        get => GetValue(ScalingStrategyProperty);
         set => SetValue(ScalingStrategyProperty, value);
     }
 
-    public static readonly DependencyProperty ScalingStrategyProperty =
-        DependencyProperty.Register("ScalingStrategy", typeof(ScalingStrategy), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(ScalingStrategy.Linear, OnScalingStrategyChanged, OnCoerceScalingStrategy));
-
+    public static readonly StyledProperty<int> FrequencyBarCountProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, int>(nameof(FrequencyBarCount), defaultValue: 25);
     public int FrequencyBarCount
     {
-        get => (int) GetValue(FrequencyBarCountProperty);
+        get => GetValue(FrequencyBarCountProperty);
         set => SetValue(FrequencyBarCountProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarCountProperty =
-        DependencyProperty.Register("FrequencyBarCount", typeof(int), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(25, OnFrequencyBarCountChanged, OnCoerceFrequencyBarCount));
-
+    public static readonly StyledProperty<int> FrequencyBarSpacingProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, int>(nameof(FrequencyBarSpacing), defaultValue: 2);
     public int FrequencyBarSpacing
     {
-        get => (int) GetValue(FrequencyBarSpacingProperty);
+        get => GetValue(FrequencyBarSpacingProperty);
         set => SetValue(FrequencyBarSpacingProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarSpacingProperty =
-        DependencyProperty.Register("FrequencyBarSpacing", typeof(int), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(2, OnFrequencyBarSpacingChanged, OnCoerceFrequencyBarSpacing));
-
-    public Brush FrequencyBarBrush
+    public static readonly StyledProperty<IBrush?> FrequencyBarBrushProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, IBrush?>(nameof(FrequencyBarBrush),
+            defaultValue: Brushes.LightGreen);
+    public IBrush? FrequencyBarBrush
     {
-        get => (Brush) GetValue(FrequencyBarBrushProperty);
+        get => GetValue(FrequencyBarBrushProperty);
         set => SetValue(FrequencyBarBrushProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarBrushProperty =
-        DependencyProperty.Register("FrequencyBarBrush", typeof(Brush), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(Brushes.LightGreen, OnFrequencyBarBrushChanged, OnCoerceFrequencyBarBrush));
-
-    public Brush FrequencyBarBorderBrush
+    public static readonly StyledProperty<IBrush?> FrequencyBarBorderBrushProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, IBrush?>(nameof(FrequencyBarBorderBrush),
+            defaultValue: Brushes.Transparent);
+    public IBrush? FrequencyBarBorderBrush
     {
-        get => (Brush) GetValue(FrequencyBarBorderBrushProperty);
+        get => GetValue(FrequencyBarBorderBrushProperty);
         set => SetValue(FrequencyBarBorderBrushProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarBorderBrushProperty =
-        DependencyProperty.Register("FrequencyBarBorderBrush", typeof(Brush), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(Brushes.Transparent, OnFrequencyBarBorderBrushChanged, OnCoerceFrequencyBarBorderBrush));
-
+    public static readonly StyledProperty<CornerRadius> FrequencyBarCornerRadiusProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, CornerRadius>(nameof(FrequencyBarCornerRadius),
+            defaultValue: new CornerRadius(1, 1, 0, 0));
     public CornerRadius FrequencyBarCornerRadius
     {
-        get => (CornerRadius) GetValue(FrequencyBarCornerRadiusProperty);
+        get => GetValue(FrequencyBarCornerRadiusProperty);
         set => SetValue(FrequencyBarCornerRadiusProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarCornerRadiusProperty =
-        DependencyProperty.Register("FrequencyBarCornerRadius", typeof(CornerRadius), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(new CornerRadius(1, 1, 0, 0), OnFrequencyBarCornerRadiusChanged, OnCoerceFrequencyBarCornerRadius));
-
+    public static readonly StyledProperty<Thickness> FrequencyBarBorderThicknessProperty =
+        AvaloniaProperty.Register<SpectrumAnalyzer, Thickness>(nameof(FrequencyBarBorderThickness),
+            defaultValue: new Thickness(0));
     public Thickness FrequencyBarBorderThickness
     {
-        get => (Thickness) GetValue(FrequencyBarBorderThicknessProperty);
+        get => GetValue(FrequencyBarBorderThicknessProperty);
         set => SetValue(FrequencyBarBorderThicknessProperty, value);
     }
 
-    public static readonly DependencyProperty FrequencyBarBorderThicknessProperty =
-        DependencyProperty.Register("FrequencyBarBorderThickness", typeof(Thickness), typeof(SpectrumAnalyzer),
-            new UIPropertyMetadata(new Thickness(0), OnFrequencyBarBorderThicknessChanged, OnCoerceFrequencyBarBorderThickness));
-
-    private void OnSourceChanged(ISource oldValue, ISource newValue)
+    // -----------------------------------------------------------------------
+    // Static ctor — wire property-changed callbacks
+    // -----------------------------------------------------------------------
+    static SpectrumAnalyzer()
     {
-        _source = Source;
+        SourceProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, e) =>
+            m.OnSourceChanged(e.GetOldValue<ISource?>(), e.GetNewValue<ISource?>()));
+
+        FrequencyBarCountProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, e) =>
+        {
+            var nv = (int) e.NewValue!;
+            if (nv < 1)
+                m.FrequencyBarCount = 1;
+            else if (nv > 100)
+                m.FrequencyBarCount = 100;
+            m.CreateBars();
+        });
+
+        BoundsProperty.Changed.AddClassHandler<SpectrumAnalyzer>((m, e) =>
+        {
+            if (e.OldValue is Rect old && e.NewValue is Rect nw && old.Size != nw.Size)
+                m.UpdateFrequencyMapping();
+        });
+    }
+
+    public SpectrumAnalyzer()
+    {
+        Content = _spectrumGrid;
+    }
+
+    // -----------------------------------------------------------------------
+    // Source wiring
+    // -----------------------------------------------------------------------
+
+    private ISource? _source;
+    private SpectrumProvider? _spectrumProvider;
+
+    private void OnSourceChanged(ISource? oldValue, ISource? newValue)
+    {
+        if (oldValue != null)
+        {
+            oldValue.SourceEvent -= OnSourceEvent;
+            oldValue.SourcePropertyChangedEvent -= OnSourcePropertyChangedEvent;
+        }
+
+        _source = newValue;
+        if (_source == null)
+            return;
+
         _source.SourceEvent += OnSourceEvent;
         _source.SourcePropertyChangedEvent += OnSourcePropertyChangedEvent;
     }
 
-    private SpectrumProvider _spectrumProvider;
-
-    private void OnSourceEvent(object sender, SourceEventArgs e)
+    private void OnSourceEvent(object? sender, SourceEventArgs e)
     {
-        if (e.Event != ESourceEventType.Loading) return;
-        _spectrumProvider = Source.Spectrum;
+        if (e.Event != ESourceEventType.Loading)
+            return;
+        _spectrumProvider = Source?.Spectrum;
         UpdateFrequencyMapping();
     }
 
-    private void OnSourcePropertyChangedEvent(object sender, SourcePropertyChangedEventArgs e)
+    private void OnSourcePropertyChangedEvent(object? sender, SourcePropertyChangedEventArgs e)
     {
         switch (e.Property)
         {
             case ESourceProperty.FftData:
-                UpdateSpectrum(SpectrumResolution, _source.FftData);
+                UpdateSpectrum(SpectrumResolution, _source!.FftData);
                 break;
-            case ESourceProperty.HideToggle when (bool) e.Value == false:
-            case ESourceProperty.PlaybackState when (PlaybackState) e.Value == PlaybackState.Playing:
-            case ESourceProperty.RecordingState when (RecordingState) e.Value == RecordingState.Recording:
+            case ESourceProperty.HideToggle when e.Value is false:
                 CreateBars();
                 break;
-            case ESourceProperty.HideToggle when (bool) e.Value:
-            case ESourceProperty.RecordingState when (RecordingState) e.Value == RecordingState.Stopped:
+            // TODO(P3-013): PlaybackState / RecordingState come from CSCore which is not available on Linux.
+            // Re-enable these case arms when the cross-platform audio backend is integrated (P3-013).
+            // case ESourceProperty.PlaybackState when (PlaybackState) e.Value == PlaybackState.Playing:
+            //     CreateBars();
+            //     break;
+            // case ESourceProperty.RecordingState when (RecordingState) e.Value == RecordingState.Recording:
+            //     CreateBars();
+            //     break;
+            case ESourceProperty.HideToggle when e.Value is true:
                 SilenceBars();
                 break;
+                // case ESourceProperty.RecordingState when (RecordingState) e.Value == RecordingState.Stopped:
+                //     SilenceBars();
+                //     break;
         }
     }
 
-    private ISource OnCoerceSource(ISource value) => value;
-
-    private static object OnCoerceSource(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceSource((ISource) value);
-        return value;
-    }
-
-    private static void OnSourceChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnSourceChanged((ISource) e.OldValue, (ISource) e.NewValue);
-    }
-
-    private ScalingStrategy OnCoerceScalingStrategy(ScalingStrategy value) => value;
-
-    private static object OnCoerceScalingStrategy(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceScalingStrategy((ScalingStrategy) value);
-        return value;
-    }
-
-    private void OnScalingStrategyChanged(ScalingStrategy oldValue, ScalingStrategy newValue)
-    {
-    }
-
-    private static void OnScalingStrategyChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnScalingStrategyChanged((ScalingStrategy) e.OldValue, (ScalingStrategy) e.NewValue);
-    }
-
-    private int OnCoerceFrequencyBarCount(int value) => value;
-
-    private static object OnCoerceFrequencyBarCount(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarCount((int) value);
-        return value;
-    }
-
-    private static void OnFrequencyBarCountChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarCountChanged((int) e.OldValue, (int) e.NewValue);
-    }
-
-    private void OnFrequencyBarCountChanged(int oldValue, int newValue)
-    {
-        FrequencyBarCount = newValue switch
-        {
-            < 1 => 1,
-            > 100 => 100,
-            _ => FrequencyBarCount
-        };
-
-        CreateBars();
-    }
-
-    private int OnCoerceFrequencyBarSpacing(int value) => value;
-
-    private static object OnCoerceFrequencyBarSpacing(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarSpacing((int) value);
-        return value;
-    }
-
-    private void OnFrequencyBarSpacingChanged(int oldValue, int newValue)
-    {
-    }
-
-    private static void OnFrequencyBarSpacingChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarSpacingChanged((int) e.OldValue, (int) e.NewValue);
-    }
-
-    private Brush OnCoerceFrequencyBarBrush(Brush value) => value;
-
-    private static object OnCoerceFrequencyBarBrush(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarBrush((Brush) value);
-        return value;
-    }
-
-    private void OnFrequencyBarBrushChanged(Brush oldValue, Brush newValue)
-    {
-    }
-
-    private static void OnFrequencyBarBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private Brush OnCoerceFrequencyBarBorderBrush(Brush value) => value;
-
-    private static object OnCoerceFrequencyBarBorderBrush(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarBorderBrush((Brush) value);
-        return value;
-    }
-
-    private void OnFrequencyBarBorderBrushChanged(Brush oldValue, Brush newValue)
-    {
-    }
-
-    private static void OnFrequencyBarBorderBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarBorderBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private CornerRadius OnCoerceFrequencyBarCornerRadius(CornerRadius value) => value;
-
-    private static object OnCoerceFrequencyBarCornerRadius(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarCornerRadius((CornerRadius) value);
-        return value;
-    }
-
-    private void OnFrequencyBarCornerRadiusChanged(CornerRadius oldValue, CornerRadius newValue)
-    {
-    }
-
-    private static void OnFrequencyBarCornerRadiusChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarCornerRadiusChanged((CornerRadius) e.OldValue, (CornerRadius) e.NewValue);
-    }
-
-    private Thickness OnCoerceFrequencyBarBorderThickness(Thickness value) => value;
-
-    private static object OnCoerceFrequencyBarBorderThickness(DependencyObject o, object value)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            return spectrumAnalyzer.OnCoerceFrequencyBarBorderThickness((Thickness) value);
-        return value;
-    }
-
-    private void OnFrequencyBarBorderThicknessChanged(Thickness oldValue, Thickness newValue)
-    {
-    }
-
-    private static void OnFrequencyBarBorderThicknessChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is SpectrumAnalyzer spectrumAnalyzer)
-            spectrumAnalyzer.OnFrequencyBarBorderThicknessChanged((Thickness) e.OldValue, (Thickness) e.NewValue);
-    }
-
-    public override void OnApplyTemplate()
-    {
-        base.OnApplyTemplate();
-
-        _spectrumGrid = GetTemplateChild("PART_Spectrum") as Grid;
-
-        CreateBars();
-        UpdateFrequencyMapping();
-    }
-
-    protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
-    {
-        UpdateFrequencyMapping();
-    }
+    // -----------------------------------------------------------------------
+    // Internal rendering constants and state
+    // -----------------------------------------------------------------------
 
     private const int ScaleFactorLinear = 50;
     private const int ScaleFactorSqr = 2;
@@ -324,21 +197,14 @@ public sealed class SpectrumAnalyzer : UserControl
     private const int SpectrumResolution = 100;
     private const double MinDbValue = -90;
     private const double DbScale = 0 - MinDbValue;
-    private int[] _spectrumIndexMax = new int[100];
+    private int[] _spectrumIndexMax = new int[SpectrumResolution];
     private int _maximumFrequencyIndex;
     private int _minimumFrequencyIndex;
 
     private void CreateBars()
     {
-        Dispatcher.BeginInvoke((Action) delegate
+        Dispatcher.UIThread.Post(() =>
         {
-            if (_spectrumGrid == null) return;
-
-            var borderBrush = FrequencyBarBorderBrush.Clone();
-            var barBrush = FrequencyBarBrush.Clone();
-            borderBrush.Freeze();
-            barBrush.Freeze();
-
             _spectrumGrid.Children.Clear();
             _bars = new Border[FrequencyBarCount];
             for (var i = 0; i < _bars.Length; i++)
@@ -350,8 +216,8 @@ public sealed class SpectrumAnalyzer : UserControl
                     HorizontalAlignment = HorizontalAlignment.Left,
                     VerticalAlignment = VerticalAlignment.Bottom,
                     Height = 0,
-                    BorderBrush = borderBrush,
-                    Background = barBrush
+                    BorderBrush = FrequencyBarBorderBrush,
+                    Background = FrequencyBarBrush,
                 };
                 _spectrumGrid.Children.Add(_bars[i]);
             }
@@ -360,22 +226,22 @@ public sealed class SpectrumAnalyzer : UserControl
 
     private void SilenceBars()
     {
-        Dispatcher.BeginInvoke((Action) delegate
-        {
-            if (_spectrumGrid == null) return;
-
-            _spectrumGrid.Children.Clear();
-            _spectrumGrid.CacheMode = new BitmapCache();
-        }, DispatcherPriority.Render);
+        Dispatcher.UIThread.Post(() => _spectrumGrid.Children.Clear(), DispatcherPriority.Render);
     }
 
     private void UpdateFrequencyMapping()
     {
-        if (_spectrumProvider == null) return;
+        if (_spectrumProvider == null)
+            return;
 
         _maximumFrequencyIndex = Math.Min(_spectrumProvider.GetFftBandIndex(MaximumFrequency) + 1, MaxFftIndex);
         _minimumFrequencyIndex = Math.Min(_spectrumProvider.GetFftBandIndex(MinimumFrequency), MaxFftIndex);
-        _spectrumIndexMax = _spectrumIndexMax.CheckBuffer(SpectrumResolution, true);
+
+        // Inline replacement for CSCore's array.CheckBuffer(size, clear):
+        if (_spectrumIndexMax.Length != SpectrumResolution)
+            _spectrumIndexMax = new int[SpectrumResolution];
+        else
+            Array.Clear(_spectrumIndexMax, 0, SpectrumResolution);
 
         var indexCount = _maximumFrequencyIndex - _minimumFrequencyIndex;
         var linearIndexBucketSize = Math.Round(indexCount / (double) SpectrumResolution, 3);
@@ -390,7 +256,7 @@ public sealed class SpectrumAnalyzer : UserControl
     private void UpdateSpectrum(double maxValue, IReadOnlyList<float> fftBuffer)
     {
         var spectrumScalingStrategy = ScalingStrategy.Decibel;
-        Dispatcher.Invoke(delegate { spectrumScalingStrategy = SpectrumScalingStrategy; });
+        Dispatcher.UIThread.Invoke(() => spectrumScalingStrategy = SpectrumScalingStrategy);
 
         var lastValue = 0D;
         var spectrumPointIndex = 0;
@@ -426,20 +292,21 @@ public sealed class SpectrumAnalyzer : UserControl
             }
         }
 
-        Dispatcher.Invoke(delegate
+        Dispatcher.UIThread.Post(() =>
         {
-            for (var i = 0; i < FrequencyBarCount; i++)
+            var barCount = Math.Min(FrequencyBarCount, dataPoints.Count);
+            for (var i = 0; i < barCount; i++)
             {
-                var barSpacing = RenderSize.Width / FrequencyBarCount;
+                var barSpacing = Bounds.Width / FrequencyBarCount;
                 var barWidth = barSpacing - FrequencyBarSpacing;
                 if (barWidth < .5)
                     barWidth = .5;
 
                 var b = _bars[i];
-                b.Height = dataPoints[i] / 100 * RenderSize.Height;
+                b.Height = dataPoints[i] / 100 * Bounds.Height;
                 b.Width = barWidth;
                 b.Margin = new Thickness(i * barSpacing, 0, 0, 0);
             }
-        }, DispatcherPriority.ApplicationIdle);
+        }, DispatcherPriority.Background);
     }
 }

--- a/FModel/Views/Resources/Controls/Aup/Timeline.cs
+++ b/FModel/Views/Resources/Controls/Aup/Timeline.cs
@@ -37,13 +37,6 @@ public sealed class Timeline : UserControl
         VerticalAlignment = VerticalAlignment.Stretch,
         IsVisible = false
     };
-    private readonly Border _bottomBorder = new()
-    {
-        Height = 1,
-        VerticalAlignment = VerticalAlignment.Bottom,
-        HorizontalAlignment = HorizontalAlignment.Stretch
-    };
-
     // -----------------------------------------------------------------------
     // Styled properties
     // -----------------------------------------------------------------------
@@ -114,8 +107,8 @@ public sealed class Timeline : UserControl
         SourceProperty.Changed.AddClassHandler<Timeline>((m, e) =>
             m.OnSourceChanged(e.GetOldValue<ISource?>(), e.GetNewValue<ISource?>()));
 
-        TickBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => m.UpdateTimeline());
-        TimeBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => m.UpdateTimeline());
+        TickBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => Dispatcher.UIThread.Post(m.UpdateTimeline));
+        TimeBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => Dispatcher.UIThread.Post(m.UpdateTimeline));
 
         ProgressBrushProperty.Changed.AddClassHandler<Timeline>((m, e) =>
             m._progressLine.Background = e.GetNewValue<IBrush?>());
@@ -162,8 +155,8 @@ public sealed class Timeline : UserControl
         Grid.SetRow(_progressLine, 1);
 
         root.Children.Add(_lengthGrid);
-        root.Children.Add(_positionLine);
         root.Children.Add(_progressLine);
+        root.Children.Add(_positionLine); // on top — must remain visible over the advancing progress fill
 
         root.PointerEntered += (_, _) => _positionLine.IsVisible = true;
         root.PointerExited += (_, _) => _positionLine.IsVisible = false;
@@ -255,8 +248,13 @@ public sealed class Timeline : UserControl
         var timeBrush = TimeBrush;
 
         // Bottom border line
-        _bottomBorder.Background = tickBrush;
-        _lengthGrid.Children.Add(_bottomBorder);
+        _lengthGrid.Children.Add(new Border
+        {
+            Height = 1,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Background = tickBrush
+        });
 
         var majorTickCount = Math.Floor(width / 100);
         var totalSeconds = _source.PlayedFile.Duration.TotalSeconds;

--- a/FModel/Views/Resources/Controls/Aup/Timeline.cs
+++ b/FModel/Views/Resources/Controls/Aup/Timeline.cs
@@ -11,11 +11,23 @@ namespace FModel.Views.Resources.Controls.Aup;
 public sealed class Timeline : UserControl
 {
     // Visual structure built directly in the constructor — no ControlTemplate needed.
+    private static readonly IBrush s_defaultProgressBrush = new LinearGradientBrush
+    {
+        StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+        EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
+        GradientStops = new GradientStops
+        {
+            new GradientStop(Color.FromRgb(0x45, 0xB6, 0x49), 0.0),
+            new GradientStop(Color.FromRgb(0xDC, 0xE3, 0x5B), 1.0)
+        }
+    };
+
     private readonly Grid _lengthGrid = new();
     private readonly Border _progressLine = new()
     {
         HorizontalAlignment = HorizontalAlignment.Left,
         VerticalAlignment = VerticalAlignment.Stretch,
+        BorderThickness = new Thickness(0, 0, 1, 0),
         Width = 0
     };
     private readonly Border _positionLine = new()
@@ -53,7 +65,8 @@ public sealed class Timeline : UserControl
     }
 
     public static readonly StyledProperty<IBrush?> TickBrushProperty =
-        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TickBrush), defaultValue: Brushes.Red);
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TickBrush),
+            defaultValue: new SolidColorBrush(Color.FromRgb(0x7F, 0x84, 0x8E)));
     public IBrush? TickBrush
     {
         get => GetValue(TickBrushProperty);
@@ -61,7 +74,8 @@ public sealed class Timeline : UserControl
     }
 
     public static readonly StyledProperty<IBrush?> TimeBrushProperty =
-        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TimeBrush), defaultValue: Brushes.Blue);
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TimeBrush),
+            defaultValue: new SolidColorBrush(Color.FromRgb(0xDA, 0xE5, 0xF2)));
     public IBrush? TimeBrush
     {
         get => GetValue(TimeBrushProperty);
@@ -69,7 +83,7 @@ public sealed class Timeline : UserControl
     }
 
     public static readonly StyledProperty<IBrush?> ProgressLineBrushProperty =
-        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressLineBrush), defaultValue: Brushes.Violet);
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressLineBrush), defaultValue: Brushes.Brown);
     public IBrush? ProgressLineBrush
     {
         get => GetValue(ProgressLineBrushProperty);
@@ -77,7 +91,7 @@ public sealed class Timeline : UserControl
     }
 
     public static readonly StyledProperty<IBrush?> ProgressBrushProperty =
-        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressBrush), defaultValue: Brushes.DarkGreen);
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressBrush), defaultValue: s_defaultProgressBrush);
     public IBrush? ProgressBrush
     {
         get => GetValue(ProgressBrushProperty);
@@ -107,6 +121,16 @@ public sealed class Timeline : UserControl
             m._progressLine.Background = e.GetNewValue<IBrush?>());
         MousePositionBrushProperty.Changed.AddClassHandler<Timeline>((m, e) =>
             m._positionLine.Background = e.GetNewValue<IBrush?>());
+        ProgressLineBrushProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+            m._progressLine.BorderBrush = e.GetNewValue<IBrush?>());
+        PositionProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+        {
+            var position = e.GetNewValue<TimeSpan>();
+            var totalMs = m._source?.PlayedFile?.Duration.TotalMilliseconds ?? 0;
+            m._progressLine.Width = totalMs > 0
+                ? position.TotalMilliseconds / totalMs * m._lengthGrid.Bounds.Width
+                : 0;
+        });
 
         // Replaces WPF OnRenderSizeChanged — re-draw ticks whenever our allocated size changes.
         BoundsProperty.Changed.AddClassHandler<Timeline>((m, e) =>
@@ -120,20 +144,33 @@ public sealed class Timeline : UserControl
     {
         // Initialise visual brushes from default property values.
         _progressLine.Background = ProgressBrush;
+        _progressLine.BorderBrush = ProgressLineBrush;
         _positionLine.Background = MousePositionBrush;
 
-        // Overlay grid: _lengthGrid (tick marks) + _progressLine + _positionLine share the same cell.
-        var overlay = new Grid();
-        overlay.Children.Add(_lengthGrid);
-        overlay.Children.Add(_progressLine);
-        overlay.Children.Add(_positionLine);
+        // Two-row layout faithful to the WPF PART_Timeline template:
+        //   Row 0 (20px): _lengthGrid (tick marks + time labels)
+        //   Row 1 (*):    _progressLine (playback progress fill + right-edge cursor border)
+        //   _positionLine (mouse cursor indicator) spans both rows.
+        var root = new Grid { ClipToBounds = true };
+        root.RowDefinitions.Add(new RowDefinition(20, GridUnitType.Pixel));
+        root.RowDefinitions.Add(new RowDefinition(1, GridUnitType.Star));
 
-        overlay.PointerEntered += (_, _) => _positionLine.IsVisible = true;
-        overlay.PointerExited += (_, _) => _positionLine.IsVisible = false;
-        overlay.PointerMoved += OnOverlayPointerMoved;
-        overlay.PointerPressed += OnOverlayPointerPressed;
+        _lengthGrid.ClipToBounds = true;
+        Grid.SetRow(_lengthGrid, 0);
+        Grid.SetRow(_positionLine, 0);
+        Grid.SetRowSpan(_positionLine, 2);
+        Grid.SetRow(_progressLine, 1);
 
-        Content = overlay;
+        root.Children.Add(_lengthGrid);
+        root.Children.Add(_positionLine);
+        root.Children.Add(_progressLine);
+
+        root.PointerEntered += (_, _) => _positionLine.IsVisible = true;
+        root.PointerExited += (_, _) => _positionLine.IsVisible = false;
+        root.PointerMoved += OnOverlayPointerMoved;
+        root.PointerPressed += OnOverlayPointerPressed;
+
+        Content = root;
     }
 
     // -----------------------------------------------------------------------
@@ -181,7 +218,7 @@ public sealed class Timeline : UserControl
         Dispatcher.UIThread.Post(UpdateTimeline);
     }
 
-    private void OnSourceEvent(object? sender, SourceEventArgs? e)
+    private void OnSourceEvent(object? sender, SourceEventArgs e)
     {
         if (Source == null)
             return;
@@ -193,15 +230,9 @@ public sealed class Timeline : UserControl
         if (e.Property != ESourceProperty.Position)
             return;
 
+        // Setting Position triggers PositionProperty.Changed which updates _progressLine.Width.
         var position = (TimeSpan) e.Value;
-        Dispatcher.UIThread.Post(() =>
-        {
-            Position = position;
-            var totalMs = _source?.PlayedFile?.Duration.TotalMilliseconds ?? 0;
-            _progressLine.Width = totalMs > 0
-                ? position.TotalMilliseconds / totalMs * _lengthGrid.Bounds.Width
-                : 0;
-        });
+        Dispatcher.UIThread.Post(() => Position = position);
     }
 
     // -----------------------------------------------------------------------

--- a/FModel/Views/Resources/Controls/Aup/Timeline.cs
+++ b/FModel/Views/Resources/Controls/Aup/Timeline.cs
@@ -1,273 +1,30 @@
 using System;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Shapes;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Threading;
 
 namespace FModel.Views.Resources.Controls.Aup;
 
-[TemplatePart(Name = "PART_ControlContainer")]
-[TemplatePart(Name = "PART_TimelineArea", Type = typeof(Border))]
-[TemplatePart(Name = "PART_MousePosition", Type = typeof(Rectangle))]
-[TemplatePart(Name = "PART_Timeline", Type = typeof(Grid))]
-[TemplatePart(Name = "PART_Length", Type = typeof(Canvas))]
-[TemplatePart(Name = "PART_ProgressLine", Type = typeof(Border))]
 public sealed class Timeline : UserControl
 {
-    private Grid _controlContainer;
-    private Border _timelineArea;
-    private Rectangle _position;
-    private Grid _timelineGrid;
-    private Grid _lengthGrid;
-    private Border _progressLine;
-
-    static Timeline()
+    // Visual structure built directly in the constructor — no ControlTemplate needed.
+    private readonly Grid _lengthGrid = new();
+    private readonly Border _progressLine = new()
     {
-        DefaultStyleKeyProperty.OverrideMetadata(typeof(Timeline), new FrameworkPropertyMetadata(typeof(Timeline)));
-    }
-
-    private ISource _source;
-    public ISource Source
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Stretch,
+        Width = 0
+    };
+    private readonly Border _positionLine = new()
     {
-        get => (ISource) GetValue(SourceProperty);
-        set => SetValue(SourceProperty, value);
-    }
-    public static readonly DependencyProperty SourceProperty =
-        DependencyProperty.Register("Source", typeof(ISource), typeof(Timeline),
-            new UIPropertyMetadata(null, OnSourceChanged, OnCoerceSource));
-
-    public TimeSpan Position
-    {
-        get => (TimeSpan) GetValue(PositionProperty);
-        set => SetValue(PositionProperty, value);
-    }
-    public static readonly DependencyProperty PositionProperty =
-        DependencyProperty.Register("Position", typeof(TimeSpan), typeof(Timeline),
-            new UIPropertyMetadata(TimeSpan.Zero, OnPositionChanged, OnCoercePosition));
-
-    public Brush TickBrush
-    {
-        get => (Brush) GetValue(TickBrushProperty);
-        set => SetValue(TickBrushProperty, value);
-    }
-    public static readonly DependencyProperty TickBrushProperty =
-        DependencyProperty.Register("TickBrush", typeof(Brush), typeof(Timeline),
-            new UIPropertyMetadata(Brushes.Red, OnTickBrushChanged, OnCoerceTickBrush));
-
-    public Brush TimeBrush
-    {
-        get => (Brush) GetValue(TimeBrushProperty);
-        set => SetValue(TimeBrushProperty, value);
-    }
-    public static readonly DependencyProperty TimeBrushProperty =
-        DependencyProperty.Register("TimeBrush", typeof(Brush), typeof(Timeline),
-            new UIPropertyMetadata(Brushes.Blue, OnTimeBrushChanged, OnCoerceTimeBrush));
-
-    public Brush ProgressLineBrush
-    {
-        get => (Brush) GetValue(ProgressLineBrushProperty);
-        set => SetValue(ProgressLineBrushProperty, value);
-    }
-    public static readonly DependencyProperty ProgressLineBrushProperty =
-        DependencyProperty.Register("ProgressLineBrush", typeof(Brush), typeof(Timeline),
-            new UIPropertyMetadata(Brushes.Violet, OnProgressLineBrushChanged, OnCoerceProgressLineBrush));
-
-    public Brush ProgressBrush
-    {
-        get => (Brush) GetValue(ProgressBrushProperty);
-        set => SetValue(ProgressBrushProperty, value);
-    }
-    public static readonly DependencyProperty ProgressBrushProperty =
-        DependencyProperty.Register("ProgressBrush", typeof(Brush), typeof(Timeline),
-            new UIPropertyMetadata(Brushes.DarkGreen, OnProgressBrushChanged, OnCoerceProgressBrush));
-
-    public Brush MousePositionBrush
-    {
-        get => (Brush) GetValue(MousePositionBrushProperty);
-        set => SetValue(MousePositionBrushProperty, value);
-    }
-    public static readonly DependencyProperty MousePositionBrushProperty =
-        DependencyProperty.Register("MousePositionBrush", typeof(Brush), typeof(Timeline),
-            new UIPropertyMetadata(Brushes.Brown, OnMousePositionBrushChanged, OnCoerceMousePositionBrush));
-
-    private void OnSourceChanged(ISource oldValue, ISource newValue)
-    {
-        _source = Source;
-        _source.SourceEvent += OnSourceEvent;
-        _source.SourcePropertyChangedEvent += OnSourcePropertyChangedEvent;
-        OnSourceEvent(this, null);
-    }
-
-    private void OnSourceEvent(object sender, SourceEventArgs e)
-    {
-        if (Source == null) return;
-        Dispatcher.BeginInvoke((Action) UpdateTimeline);
-    }
-
-    private void OnSourcePropertyChangedEvent(object sender, SourcePropertyChangedEventArgs e)
-    {
-        if (e.Property != ESourceProperty.Position) return;
-
-        var position = (TimeSpan) e.Value;
-        Dispatcher.BeginInvoke((Action) delegate
-        {
-            Position = position;
-            if (_lengthGrid == null) return;
-
-            var x = 0d;
-            if (_source.PlayedFile.Duration.TotalMilliseconds != 0)
-            {
-                x = position.TotalMilliseconds / _source.PlayedFile.Duration.TotalMilliseconds * _lengthGrid.RenderSize.Width;
-            }
-
-            _progressLine.Width = x;
-        });
-    }
-
-    private ISource OnCoerceSource(ISource value) => value;
-    private static object OnCoerceSource(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceSource((ISource) value);
-        return value;
-    }
-
-    private static void OnSourceChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnSourceChanged((ISource) e.OldValue, (ISource) e.NewValue);
-    }
-
-    private TimeSpan OnCoercePosition(TimeSpan value) => value;
-    private static object OnCoercePosition(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoercePosition((TimeSpan) value);
-        return value;
-    }
-
-    private void OnPositionChanged(TimeSpan oldValue, TimeSpan newValue)
-    {
-    }
-
-    private static void OnPositionChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnPositionChanged((TimeSpan) e.OldValue, (TimeSpan) e.NewValue);
-    }
-
-    private Brush OnCoerceTickBrush(Brush value) => value;
-    private static object OnCoerceTickBrush(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceTickBrush((Brush) value);
-        return value;
-    }
-
-    private void OnTickBrushChanged(Brush oldValue, Brush newValue) => UpdateTimeline();
-    private static void OnTickBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnTickBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private Brush OnCoerceTimeBrush(Brush value) => value;
-    private static object OnCoerceTimeBrush(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceTimeBrush((Brush) value);
-        return value;
-    }
-
-    private void OnTimeBrushChanged(Brush oldValue, Brush newValue) => UpdateTimeline();
-    private static void OnTimeBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnTimeBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private Brush OnCoerceProgressLineBrush(Brush value) => value;
-    private static object OnCoerceProgressLineBrush(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceProgressLineBrush((Brush) value);
-        return value;
-    }
-
-    private void OnProgressLineBrushChanged(Brush oldValue, Brush newValue)
-    {
-    }
-
-    private static void OnProgressLineBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnProgressLineBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private Brush OnCoerceProgressBrush(Brush value) => value;
-    private static object OnCoerceProgressBrush(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceProgressBrush((Brush) value);
-        return value;
-    }
-
-    private void OnProgressBrushChanged(Brush oldValue, Brush newValue)
-    {
-    }
-
-    private static void OnProgressBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnProgressBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    private Brush OnCoerceMousePositionBrush(Brush value) => value;
-    private static object OnCoerceMousePositionBrush(DependencyObject o, object value)
-    {
-        if (o is Timeline timeline)
-            return timeline.OnCoerceMousePositionBrush((Brush) value);
-        return value;
-    }
-
-    private void OnMousePositionBrushChanged(Brush oldValue, Brush newValue)
-    {
-    }
-
-    private static void OnMousePositionBrushChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-    {
-        if (o is Timeline timeline)
-            timeline.OnMousePositionBrushChanged((Brush) e.OldValue, (Brush) e.NewValue);
-    }
-
-    public override void OnApplyTemplate()
-    {
-        base.OnApplyTemplate();
-
-        _controlContainer = GetTemplateChild("PART_ControlContainer") as Grid;
-        _timelineGrid = GetTemplateChild("PART_Timeline") as Grid;
-        _lengthGrid = GetTemplateChild("PART_Length") as Grid;
-        _progressLine = GetTemplateChild("PART_ProgressLine") as Border;
-        _timelineGrid.CacheMode = new BitmapCache();
-
-        _timelineArea = GetTemplateChild("PART_TimelineArea") as Border;
-        _position = GetTemplateChild("PART_MousePosition") as Rectangle;
-        _timelineArea.MouseEnter += (_, _) => _position.Visibility = Visibility.Visible;
-        _timelineArea.MouseLeave += (_, _) => _position.Visibility = Visibility.Collapsed;
-        _timelineArea.MouseMove += (_, args)
-            => _position.Margin = new Thickness(args.GetPosition(_timelineArea).X, 0, _position.ActualWidth, 0);
-        _timelineArea.MouseLeftButtonDown += (_, args)
-            => Source.SkipTo(args.GetPosition(_timelineArea).X / _timelineArea.ActualWidth);
-
-        OnSourceEvent(this, null);
-    }
-
-    protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
-    {
-        base.OnRenderSizeChanged(sizeInfo);
-        UpdateTimeline();
-    }
-
+        Width = 1,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Stretch,
+        IsVisible = false
+    };
     private readonly Border _bottomBorder = new()
     {
         Height = 1,
@@ -275,26 +32,201 @@ public sealed class Timeline : UserControl
         HorizontalAlignment = HorizontalAlignment.Stretch
     };
 
+    // -----------------------------------------------------------------------
+    // Styled properties
+    // -----------------------------------------------------------------------
+
+    public static readonly StyledProperty<ISource?> SourceProperty =
+        AvaloniaProperty.Register<Timeline, ISource?>(nameof(Source));
+    public ISource? Source
+    {
+        get => GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    public static readonly StyledProperty<TimeSpan> PositionProperty =
+        AvaloniaProperty.Register<Timeline, TimeSpan>(nameof(Position), defaultValue: TimeSpan.Zero);
+    public TimeSpan Position
+    {
+        get => GetValue(PositionProperty);
+        set => SetValue(PositionProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> TickBrushProperty =
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TickBrush), defaultValue: Brushes.Red);
+    public IBrush? TickBrush
+    {
+        get => GetValue(TickBrushProperty);
+        set => SetValue(TickBrushProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> TimeBrushProperty =
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(TimeBrush), defaultValue: Brushes.Blue);
+    public IBrush? TimeBrush
+    {
+        get => GetValue(TimeBrushProperty);
+        set => SetValue(TimeBrushProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> ProgressLineBrushProperty =
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressLineBrush), defaultValue: Brushes.Violet);
+    public IBrush? ProgressLineBrush
+    {
+        get => GetValue(ProgressLineBrushProperty);
+        set => SetValue(ProgressLineBrushProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> ProgressBrushProperty =
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(ProgressBrush), defaultValue: Brushes.DarkGreen);
+    public IBrush? ProgressBrush
+    {
+        get => GetValue(ProgressBrushProperty);
+        set => SetValue(ProgressBrushProperty, value);
+    }
+
+    public static readonly StyledProperty<IBrush?> MousePositionBrushProperty =
+        AvaloniaProperty.Register<Timeline, IBrush?>(nameof(MousePositionBrush), defaultValue: Brushes.Brown);
+    public IBrush? MousePositionBrush
+    {
+        get => GetValue(MousePositionBrushProperty);
+        set => SetValue(MousePositionBrushProperty, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Static ctor — wire property-changed callbacks
+    // -----------------------------------------------------------------------
+    static Timeline()
+    {
+        SourceProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+            m.OnSourceChanged(e.GetOldValue<ISource?>(), e.GetNewValue<ISource?>()));
+
+        TickBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => m.UpdateTimeline());
+        TimeBrushProperty.Changed.AddClassHandler<Timeline>((m, _) => m.UpdateTimeline());
+
+        ProgressBrushProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+            m._progressLine.Background = e.GetNewValue<IBrush?>());
+        MousePositionBrushProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+            m._positionLine.Background = e.GetNewValue<IBrush?>());
+
+        // Replaces WPF OnRenderSizeChanged — re-draw ticks whenever our allocated size changes.
+        BoundsProperty.Changed.AddClassHandler<Timeline>((m, e) =>
+        {
+            if (e.OldValue is Rect old && e.NewValue is Rect nw && old.Size != nw.Size)
+                m.UpdateTimeline();
+        });
+    }
+
+    public Timeline()
+    {
+        // Initialise visual brushes from default property values.
+        _progressLine.Background = ProgressBrush;
+        _positionLine.Background = MousePositionBrush;
+
+        // Overlay grid: _lengthGrid (tick marks) + _progressLine + _positionLine share the same cell.
+        var overlay = new Grid();
+        overlay.Children.Add(_lengthGrid);
+        overlay.Children.Add(_progressLine);
+        overlay.Children.Add(_positionLine);
+
+        overlay.PointerEntered += (_, _) => _positionLine.IsVisible = true;
+        overlay.PointerExited += (_, _) => _positionLine.IsVisible = false;
+        overlay.PointerMoved += OnOverlayPointerMoved;
+        overlay.PointerPressed += OnOverlayPointerPressed;
+
+        Content = overlay;
+    }
+
+    // -----------------------------------------------------------------------
+    // Pointer handlers (replaces WPF MouseEnter/Leave/Move/LeftButtonDown)
+    // -----------------------------------------------------------------------
+
+    private void OnOverlayPointerMoved(object? sender, PointerEventArgs e)
+    {
+        var x = e.GetPosition((Visual?) sender).X;
+        _positionLine.Margin = new Thickness(x, 0, 0, 0);
+    }
+
+    private void OnOverlayPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+            return;
+        if (Source == null)
+            return;
+        var overlayWidth = ((Control?) sender)?.Bounds.Width ?? 0;
+        if (overlayWidth <= 0)
+            return;
+        Source.SkipTo(e.GetPosition((Visual?) sender).X / overlayWidth);
+    }
+
+    // -----------------------------------------------------------------------
+    // Source wiring
+    // -----------------------------------------------------------------------
+
+    private ISource? _source;
+
+    private void OnSourceChanged(ISource? oldValue, ISource? newValue)
+    {
+        if (oldValue != null)
+        {
+            oldValue.SourceEvent -= OnSourceEvent;
+            oldValue.SourcePropertyChangedEvent -= OnSourcePropertyChangedEvent;
+        }
+
+        _source = newValue;
+        if (_source == null)
+            return;
+
+        _source.SourceEvent += OnSourceEvent;
+        _source.SourcePropertyChangedEvent += OnSourcePropertyChangedEvent;
+        Dispatcher.UIThread.Post(UpdateTimeline);
+    }
+
+    private void OnSourceEvent(object? sender, SourceEventArgs? e)
+    {
+        if (Source == null)
+            return;
+        Dispatcher.UIThread.Post(UpdateTimeline);
+    }
+
+    private void OnSourcePropertyChangedEvent(object? sender, SourcePropertyChangedEventArgs e)
+    {
+        if (e.Property != ESourceProperty.Position)
+            return;
+
+        var position = (TimeSpan) e.Value;
+        Dispatcher.UIThread.Post(() =>
+        {
+            Position = position;
+            var totalMs = _source?.PlayedFile?.Duration.TotalMilliseconds ?? 0;
+            _progressLine.Width = totalMs > 0
+                ? position.TotalMilliseconds / totalMs * _lengthGrid.Bounds.Width
+                : 0;
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Timeline rendering (replaces WPF UpdateTimeline)
+    // -----------------------------------------------------------------------
+
     private void UpdateTimeline()
     {
-        if (_source == null || _source.PlayedFile.Duration == TimeSpan.Zero || _lengthGrid == null ||
-            _lengthGrid.RenderSize.Width < 1 || _lengthGrid.RenderSize.Height < 1) return;
+        if (_source == null || _source.PlayedFile.Duration == TimeSpan.Zero)
+            return;
+
+        var width = _lengthGrid.Bounds.Width;
+        var height = _lengthGrid.Bounds.Height;
+        if (width < 1 || height < 1)
+            return;
 
         _lengthGrid.Children.Clear();
 
-        // freeze brushes
-        var tickBrush = TickBrush.Clone();
-        var timeBrush = TimeBrush.Clone();
-        tickBrush.Freeze();
-        timeBrush.Freeze();
+        var tickBrush = TickBrush;
+        var timeBrush = TimeBrush;
 
-        // Draw the bottom border
+        // Bottom border line
         _bottomBorder.Background = tickBrush;
         _lengthGrid.Children.Add(_bottomBorder);
 
-        // Determine the number of major ticks that we should display.
-        // This depends on the width of the timeline.
-        var width = _lengthGrid.RenderSize.Width;
         var majorTickCount = Math.Floor(width / 100);
         var totalSeconds = _source.PlayedFile.Duration.TotalSeconds;
         var majorTickSecondInterval = Math.Floor(totalSeconds / majorTickCount);
@@ -323,7 +255,7 @@ public sealed class Timeline : UserControl
             }
             else
             {
-                // Major tick
+                // Major tick — full height
                 _lengthGrid.Children.Add(new Border
                 {
                     Width = 1,
@@ -333,17 +265,16 @@ public sealed class Timeline : UserControl
                     Margin = new Thickness(x, 0, 0, 0)
                 });
 
-                // Add time label
-                var time = new TextBlock
+                // Time label
+                var ts = TimeSpan.FromSeconds(interval);
+                _lengthGrid.Children.Add(new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Bottom,
                     HorizontalAlignment = HorizontalAlignment.Left,
-                    Foreground = timeBrush
-                };
-                var ts = TimeSpan.FromSeconds(interval);
-                time.Text = ts.TotalHours >= 1 ? ts.ToString(@"h\:mm\:ss") : ts.ToString(@"mm\:ss");
-                time.Margin = new Thickness(x + 5, 0, 0, 7);
-                _lengthGrid.Children.Add(time);
+                    Foreground = timeBrush,
+                    Text = ts.TotalHours >= 1 ? ts.ToString(@"h\:mm\:ss") : ts.ToString(@"mm\:ss"),
+                    Margin = new Thickness(x + 5, 0, 0, 7)
+                });
             }
         }
     }

--- a/FModel/Views/Resources/Controls/Aup/Timeline.cs
+++ b/FModel/Views/Resources/Controls/Aup/Timeline.cs
@@ -125,11 +125,16 @@ public sealed class Timeline : UserControl
                 : 0;
         });
 
-        // Replaces WPF OnRenderSizeChanged — re-draw ticks whenever our allocated size changes.
+        // Replaces WPF OnRenderSizeChanged — re-draw ticks and recompute progress width when size changes.
         BoundsProperty.Changed.AddClassHandler<Timeline>((m, e) =>
         {
             if (e.OldValue is Rect old && e.NewValue is Rect nw && old.Size != nw.Size)
+            {
                 m.UpdateTimeline();
+                var totalMs = m._source?.PlayedFile?.Duration.TotalMilliseconds ?? 0;
+                if (totalMs > 0)
+                    m._progressLine.Width = m.Position.TotalMilliseconds / totalMs * nw.Width;
+            }
         });
     }
 
@@ -185,7 +190,8 @@ public sealed class Timeline : UserControl
         var overlayWidth = ((Control?) sender)?.Bounds.Width ?? 0;
         if (overlayWidth <= 0)
             return;
-        Source.SkipTo(e.GetPosition((Visual?) sender).X / overlayWidth);
+        var ratio = e.GetPosition((Visual?) sender).X / overlayWidth;
+        Source.SkipTo(Math.Clamp(ratio, 0.0, 1.0));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #21

## Summary

Migrates the two WPF `UserControl` classes in `Aup/` to Avalonia UI, maintaining full behavioral parity.

### `SpectrumAnalyzer.cs`
- Already partially migrated in a previous pass; removed the remaining dead WPF stub method (`OnFrequencyBarBorderThicknessChanged`) that referenced `DependencyObject` and `DependencyPropertyChangedEventArgs`.
- All `StyledProperty` registrations, `AddClassHandler` static ctor, and `Dispatcher.UIThread.Post` patterns were already correct.

### `Timeline.cs`
Full rewrite from WPF to Avalonia:

| WPF | Avalonia |
|---|---|
| `DependencyProperty.Register` + `FrameworkPropertyMetadata` | `StyledProperty<T>.Register` |
| Static `PropertyChangedCallback` | `AddClassHandler<Timeline>` in static ctor |
| `Dispatcher.BeginInvoke` | `Dispatcher.UIThread.Post` |
| `Visibility.Visible/Collapsed` | `IsVisible = true/false` |
| `MouseMove` / `MouseLeftButtonDown` | `PointerMove` / `PointerPressed` (left-button filtered via `PointerUpdateKind`) |
| `OnRenderSizeChanged(SizeChangedInfo)` | `BoundsProperty.Changed` subscription |
| `DefaultStyleKeyProperty.OverrideMetadata` | Removed (composition-based; no ControlTheme) |
| WPF `UserControl` with XAML template | Avalonia `UserControl` with visual children built in constructor |

Visual composition is done entirely in the constructor (`Grid` → `Border` → overlay `Canvas` → `Rectangle`), with no separate XAML template file — matching the pattern established in `SpectrumAnalyzer.cs`.

## Out of scope
Pre-existing errors in `CustomCodecFactory.cs`, `NVorbisSource.cs`, `SpectrumProvider.cs` (CSCore — tracked in P3-013), and `Timeclock.cs` (separate migration issue) are unchanged.