### PR TITLE
feat(aed): Replace ICSharpCode.AvalonEdit with AvaloniaEdit [P2-008]

### DIFF
--- a/FModel/Extensions/AvalonExtensions.cs
+++ b/FModel/Extensions/AvalonExtensions.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Xml;
-using ICSharpCode.AvalonEdit.Highlighting;
-using ICSharpCode.AvalonEdit.Highlighting.Xshd;
+using AvaloniaEdit.Highlighting;
+using AvaloniaEdit.Highlighting.Xshd;
 
 namespace FModel.Extensions;
 

--- a/FModel/Extensions/StringExtensions.cs
+++ b/FModel/Extensions/StringExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using ICSharpCode.AvalonEdit.Document;
+using AvaloniaEdit.Document;
 
 namespace FModel.Extensions;
 
@@ -11,7 +11,8 @@ public static partial class StringExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetReadableSize(double size)
     {
-        if (size == 0) return "0 B";
+        if (size == 0)
+            return "0 B";
 
         string[] sizes = ["B", "KB", "MB", "GB", "TB"];
         var order = 0;
@@ -62,7 +63,8 @@ public static partial class StringExtensions
                 return content.Split("\"")[3];
 
             lineNumber--;
-            if (lineNumber < 1) break;
+            if (lineNumber < 1)
+                break;
             line = doc.GetLineByNumber(lineNumber);
         }
 

--- a/FModel/ViewModels/TabControlViewModel.cs
+++ b/FModel/ViewModels/TabControlViewModel.cs
@@ -4,8 +4,8 @@ using FModel.Framework;
 using FModel.Settings;
 using FModel.ViewModels.Commands;
 using FModel.Views.Resources.Controls;
-using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit.Highlighting;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Highlighting;
 using Serilog;
 using SkiaSharp;
 using System.Collections.ObjectModel;
@@ -46,7 +46,8 @@ public class TabImage : ViewModel
         get => _image;
         set
         {
-            if (_image == value) return;
+            if (_image == value)
+                return;
             SetProperty(ref _image, value);
         }
     }
@@ -230,7 +231,8 @@ public class TabItem : ViewModel
         get => _highlighter;
         set
         {
-            if (_highlighter == value) return;
+            if (_highlighter == value)
+                return;
             SetProperty(ref _highlighter, value);
         }
     }
@@ -241,7 +243,8 @@ public class TabItem : ViewModel
         get => _selectedImage;
         set
         {
-            if (_selectedImage == value) return;
+            if (_selectedImage == value)
+                return;
             SetProperty(ref _selectedImage, value);
             RaisePropertyChanged("HasImage");
             RaisePropertyChanged("Page");
@@ -331,8 +334,10 @@ public class TabItem : ViewModel
         Application.Current.Dispatcher.Invoke(() =>
         {
             var t = new TabImage(name, rnn, img);
-            if (save) SaveImage(t, updateUi);
-            if (!updateUi) return;
+            if (save)
+                SaveImage(t, updateUi);
+            if (!updateUi)
+                return;
 
             _images.Add(t);
             SelectedImage ??= t;
@@ -346,8 +351,10 @@ public class TabItem : ViewModel
         Application.Current.Dispatcher.Invoke(() =>
         {
             var t = new TabImage(name, rnn, img);
-            if (save) SaveImage(t, updateUi);
-            if (!updateUi) return;
+            if (save)
+                SaveImage(t, updateUi);
+            if (!updateUi)
+                return;
 
             _images.Add(t);
             SelectedImage ??= t;
@@ -367,7 +374,8 @@ public class TabItem : ViewModel
             Document.Text = text;
             Document.UndoStack.ClearAll();
 
-            if (save) SaveProperty(updateUi);
+            if (save)
+                SaveProperty(updateUi);
         });
     }
 
@@ -466,7 +474,8 @@ public class TabControlViewModel : ViewModel
             return;
         }
 
-        if (!CanAddTabs) return;
+        if (!CanAddTabs)
+            return;
         Application.Current.Dispatcher.Invoke(() =>
         {
             _tabItems.Add(new TabItem(entry, parentExportType ?? string.Empty));

--- a/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
+++ b/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
-using ICSharpCode.AvalonEdit;
-using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit.Folding;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Folding;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -51,7 +51,8 @@ public class JsonFoldingStrategies
         var foldunfold = false;
         foreach (var folding in _foldingManager.AllFoldings)
         {
-            if (folding.Tag is not CustomNewFolding realFolding || realFolding.Level != level) continue;
+            if (folding.Tag is not CustomNewFolding realFolding || realFolding.Level != level)
+                continue;
 
             if (dowhat < 0) // determine if we fold or unfold based on the first one
             {
@@ -93,16 +94,16 @@ public class BraceFoldingStrategy
                     startOffsets.Push(i);
                     break;
                 case '}' or ']' when startOffsets.Count > 0:
-                {
-                    var startOffset = startOffsets.Pop();
-                    if (startOffset < lastNewLineOffset)
                     {
-                        newFoldings.Add(new CustomNewFolding(startOffset, i + 1, level));
-                    }
+                        var startOffset = startOffsets.Pop();
+                        if (startOffset < lastNewLineOffset)
+                        {
+                            newFoldings.Add(new CustomNewFolding(startOffset, i + 1, level));
+                        }
 
-                    level--;
-                    break;
-                }
+                        level--;
+                        break;
+                    }
                 case '\n' or '\r':
                     lastNewLineOffset = i + 1;
                     break;

--- a/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
+++ b/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
@@ -69,7 +69,8 @@ public class BraceFoldingStrategy
 {
     public BraceFoldingStrategy(TextEditor editor)
     {
-        UpdateFoldings(editor.Document);
+        // Initial folding installation is handled by JsonFoldingStrategies.UpdateFoldings;
+        // no eager parse needed here.
     }
 
     public IEnumerable<CustomNewFolding> UpdateFoldings(TextDocument document)

--- a/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
+++ b/FModel/Views/Resources/Controls/Aed/BraceFoldingStrategy.cs
@@ -13,7 +13,7 @@ public class JsonFoldingStrategies
     public JsonFoldingStrategies(TextEditor avalonEditor)
     {
         _foldingManager = FoldingManager.Install(avalonEditor.TextArea);
-        _strategy = new BraceFoldingStrategy(avalonEditor);
+        _strategy = new BraceFoldingStrategy();
     }
 
     public void UpdateFoldings(TextDocument document)
@@ -67,10 +67,8 @@ public class JsonFoldingStrategies
 
 public class BraceFoldingStrategy
 {
-    public BraceFoldingStrategy(TextEditor editor)
+    public BraceFoldingStrategy()
     {
-        // Initial folding installation is handled by JsonFoldingStrategies.UpdateFoldings;
-        // no eager parse needed here.
     }
 
     public IEnumerable<CustomNewFolding> UpdateFoldings(TextDocument document)

--- a/FModel/Views/Resources/Controls/Aed/GamePathElementGenerator.cs
+++ b/FModel/Views/Resources/Controls/Aed/GamePathElementGenerator.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 using FModel.Extensions;
-using ICSharpCode.AvalonEdit.Rendering;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -31,7 +31,8 @@ public class GamePathElementGenerator : VisualLineElementGenerator
     {
         var m = FindMatch(offset);
         if (!m.Success || m.Index != 0 ||
-            !m.Groups.TryGetValue("target", out var g)) return null;
+            !m.Groups.TryGetValue("target", out var g))
+            return null;
 
         var parentExportType = CurrentContext.Document.GetParentExportType(offset);
         return new GamePathVisualLineText(g.Value, parentExportType, CurrentContext.VisualLine, g.Length + g.Index + 1);

--- a/FModel/Views/Resources/Controls/Aed/GamePathVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/GamePathVisualLineText.cs
@@ -36,6 +36,8 @@ public class GamePathVisualLineText : VisualLineText
         var runLength = DocumentLength - (startVisualColumn - VisualColumn);
         if (runLength != 2) // skip separator tokens
             TextRunProperties.SetForegroundBrush(Brushes.Plum);
+        else
+            TextRunProperties.SetForegroundBrush(null); // restore default for separator token
 
         return base.CreateTextRun(startVisualColumn, context);
     }

--- a/FModel/Views/Resources/Controls/Aed/GamePathVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/GamePathVisualLineText.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Text.RegularExpressions;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.TextFormatting;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
 using CUE4Parse.Utils;
 using FModel.Extensions;
 using FModel.Services;
 using FModel.ViewModels;
-using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit.Rendering;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -31,30 +31,21 @@ public class GamePathVisualLineText : VisualLineText
 
     public override TextRun CreateTextRun(int startVisualColumn, ITextRunConstructionContext context)
     {
-        if (context == null)
-            throw new ArgumentNullException(nameof(context));
+        ArgumentNullException.ThrowIfNull(context);
 
-        var relativeOffset = startVisualColumn - VisualColumn;
-        var text = context.GetText(context.VisualLine.FirstDocumentLine.Offset + RelativeTextOffset + relativeOffset, DocumentLength - relativeOffset);
-
-        if (text.Count != 2) // ": "
+        var runLength = DocumentLength - (startVisualColumn - VisualColumn);
+        if (runLength != 2) // skip separator tokens
             TextRunProperties.SetForegroundBrush(Brushes.Plum);
 
-        return new TextCharacters(text.Text, text.Offset, text.Count, TextRunProperties);
+        return base.CreateTextRun(startVisualColumn, context);
     }
 
-    private bool GamePathIsClickable() => !string.IsNullOrEmpty(_gamePath) && Keyboard.Modifiers == ModifierKeys.None;
+    private bool GamePathIsClickable(KeyModifiers modifiers) =>
+        !string.IsNullOrEmpty(_gamePath) && modifiers == KeyModifiers.None;
 
-    protected override void OnQueryCursor(QueryCursorEventArgs e)
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
-        if (!GamePathIsClickable()) return;
-        e.Handled = true;
-        e.Cursor = Cursors.Hand;
-    }
-
-    protected override void OnMouseDown(MouseButtonEventArgs e)
-    {
-        if (e.ChangedButton != MouseButton.Left || !GamePathIsClickable())
+        if (!e.GetCurrentPoint(null).Properties.IsLeftButtonPressed || !GamePathIsClickable(e.KeyModifiers))
             return;
         if (e.Handled || OnGamePathClicked == null)
             return;

--- a/FModel/Views/Resources/Controls/Aed/HexColorElementGenerator.cs
+++ b/FModel/Views/Resources/Controls/Aed/HexColorElementGenerator.cs
@@ -1,5 +1,5 @@
 using System.Text.RegularExpressions;
-using ICSharpCode.AvalonEdit.Rendering;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -28,7 +28,8 @@ public class HexColorElementGenerator : VisualLineElementGenerator
     public override VisualLineElement ConstructElement(int offset)
     {
         var m = FindMatch(offset);
-        if (!m.Success || m.Index != 0) return null;
+        if (!m.Success || m.Index != 0)
+            return null;
 
         return m.Groups.TryGetValue("target", out var g) ?
             new HexColorVisualLineText(g.Value, CurrentContext.VisualLine, g.Length + g.Index + 1) :

--- a/FModel/Views/Resources/Controls/Aed/HexColorVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/HexColorVisualLineText.cs
@@ -22,6 +22,8 @@ public class HexColorVisualLineText : VisualLineText
         var runLength = DocumentLength - (startVisualColumn - VisualColumn);
         if (runLength != 2)
             TextRunProperties.SetForegroundBrush(Brushes.PeachPuff);
+        else
+            TextRunProperties.SetForegroundBrush(null); // restore default for separator token
 
         return base.CreateTextRun(startVisualColumn, context);
     }

--- a/FModel/Views/Resources/Controls/Aed/HexColorVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/HexColorVisualLineText.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Windows.Media;
-using System.Windows.Media.TextFormatting;
-using ICSharpCode.AvalonEdit.Rendering;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -16,16 +16,14 @@ public class HexColorVisualLineText : VisualLineText
 
     public override TextRun CreateTextRun(int startVisualColumn, ITextRunConstructionContext context)
     {
-        if (context == null)
-            throw new ArgumentNullException(nameof(context));
+        ArgumentNullException.ThrowIfNull(context);
 
-        var relativeOffset = startVisualColumn - VisualColumn;
-        var text = context.GetText(context.VisualLine.FirstDocumentLine.Offset + RelativeTextOffset + relativeOffset, DocumentLength - relativeOffset);
-
-        if (text.Count != 2) // ": "
+        // Apply custom colour to everything except the 2-char separator token (":\xa0").
+        var runLength = DocumentLength - (startVisualColumn - VisualColumn);
+        if (runLength != 2)
             TextRunProperties.SetForegroundBrush(Brushes.PeachPuff);
 
-        return new TextCharacters(text.Text, text.Offset, text.Count, TextRunProperties);
+        return base.CreateTextRun(startVisualColumn, context);
     }
 
     protected override VisualLineText CreateInstance(int length)

--- a/FModel/Views/Resources/Controls/Aed/JumpElementGenerator.cs
+++ b/FModel/Views/Resources/Controls/Aed/JumpElementGenerator.cs
@@ -1,5 +1,5 @@
 using System.Text.RegularExpressions;
-using ICSharpCode.AvalonEdit.Rendering;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 

--- a/FModel/Views/Resources/Controls/Aed/JumpVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/JumpVisualLineText.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.TextFormatting;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
 using FModel.Extensions;
 using FModel.Services;
 using FModel.ViewModels;
-using ICSharpCode.AvalonEdit.Rendering;
+using AvaloniaEdit.Rendering;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -23,31 +23,21 @@ public class JumpVisualLineText : VisualLineText
 
     public override TextRun CreateTextRun(int startVisualColumn, ITextRunConstructionContext context)
     {
-        if (context == null)
-            throw new ArgumentNullException(nameof(context));
+        ArgumentNullException.ThrowIfNull(context);
 
-        var relativeOffset = startVisualColumn - VisualColumn;
-        var text = context.GetText(context.VisualLine.FirstDocumentLine.Offset + RelativeTextOffset + relativeOffset, DocumentLength - relativeOffset);
-
-        if (text.Count != 2) // ": "
+        var runLength = DocumentLength - (startVisualColumn - VisualColumn);
+        if (runLength != 2) // skip separator tokens
             TextRunProperties.SetForegroundBrush(Brushes.Plum);
 
-        return new TextCharacters(text.Text, text.Offset, text.Count, TextRunProperties);
+        return base.CreateTextRun(startVisualColumn, context);
     }
 
-    private bool JumpIsClickable() => !string.IsNullOrEmpty(_jump) && Keyboard.Modifiers == ModifierKeys.None;
+    private bool JumpIsClickable(KeyModifiers modifiers) =>
+        !string.IsNullOrEmpty(_jump) && modifiers == KeyModifiers.None;
 
-    protected override void OnQueryCursor(QueryCursorEventArgs e)
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
-        if (!JumpIsClickable())
-            return;
-        e.Handled = true;
-        e.Cursor = Cursors.Hand;
-    }
-
-    protected override void OnMouseDown(MouseButtonEventArgs e)
-    {
-        if (e.ChangedButton != MouseButton.Left || !JumpIsClickable())
+        if (!e.GetCurrentPoint(null).Properties.IsLeftButtonPressed || !JumpIsClickable(e.KeyModifiers))
             return;
         if (e.Handled || OnJumpClicked == null)
             return;

--- a/FModel/Views/Resources/Controls/Aed/JumpVisualLineText.cs
+++ b/FModel/Views/Resources/Controls/Aed/JumpVisualLineText.cs
@@ -28,6 +28,8 @@ public class JumpVisualLineText : VisualLineText
         var runLength = DocumentLength - (startVisualColumn - VisualColumn);
         if (runLength != 2) // skip separator tokens
             TextRunProperties.SetForegroundBrush(Brushes.Plum);
+        else
+            TextRunProperties.SetForegroundBrush(null); // restore default for separator token
 
         return base.CreateTextRun(startVisualColumn, context);
     }

--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml
@@ -1,111 +1,150 @@
 ﻿<UserControl x:Class="FModel.Views.Resources.Controls.AvalonEditor"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:adonisUi="clr-namespace:AdonisUI;assembly=AdonisUI"
-             xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
-             xmlns:adonisExtensions="clr-namespace:AdonisUI.Extensions;assembly=AdonisUI"
-             PreviewKeyDown="OnPreviewKeyDown">
+             xmlns:avalonEdit="https://github.com/avaloniaui/avaloniaedit"
+             KeyDown="OnPreviewKeyDown">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Margin="3 0" HorizontalAlignment="Right" Width="500">
-            <Grid.Style>
-                <Style TargetType="{x:Type Grid}">
-                    <Setter Property="ZIndex" Value="0" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding HasSearchOpen}" Value="True">
-                            <Setter Property="ZIndex" Value="1" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Grid.Style>
+        <!-- Search panel — shown on top of the TextEditor when HasSearchOpen=True. -->
+        <Grid Grid.Row="0"
+              Margin="3 0"
+              HorizontalAlignment="Right"
+              Width="500"
+              IsVisible="{Binding HasSearchOpen}"
+              ZIndex="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Grid Grid.Column="0" ZIndex="1" HorizontalAlignment="Left" Margin="5 2 0 0">
-                <Viewbox Width="16" Height="16">
-                    <Canvas Width="24" Height="24">
-                        <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource SearchIcon}" />
+            <Grid Grid.Column="0"
+                  ZIndex="1"
+                  HorizontalAlignment="Left"
+                  Margin="5 2 0 0">
+                <Viewbox Width="16"
+                         Height="16">
+                    <Canvas Width="24"
+                            Height="24">
+                        <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                              Data="{StaticResource SearchIcon}" />
                     </Canvas>
                 </Viewbox>
             </Grid>
-            <TextBox x:Name="WpfSuckMyDick" Grid.Column="0" Grid.ColumnSpan="2" Padding="25 0 0 0" AcceptsTab="False" AcceptsReturn="False"
-                     BorderBrush="{DynamicResource {x:Static adonisUi:Brushes.AccentBrush}}" BorderThickness="1">
-                <TextBox.Style>
-                    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-                        <Setter Property="Text" Value="{Binding TextToFind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <Setter Property="adonisExtensions:WatermarkExtension.Watermark" Value="Write your pattern and press enter..." />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding UseRegEx}" Value="True">
-                                <Setter Property="adonisExtensions:WatermarkExtension.Watermark" Value="Write your regex pattern and press enter..." />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBox.Style>
-            </TextBox>
-            <StackPanel Grid.Column="1" Orientation="Horizontal">
-                <ToggleButton ToolTip="Search Up" Padding="5" IsChecked="{Binding SearchUp}" Focusable="False"
-                              Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarToggleButton}}">
-                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource SearchUpIcon}" />
+            <TextBox x:Name="WpfSuckMyDick"
+                     Grid.Column="0"
+                     Grid.ColumnSpan="2"
+                     Padding="25 0 0 0"
+                     AcceptsTab="False"
+                     AcceptsReturn="False"
+                     Text="{Binding TextToFind, Mode=TwoWay}"
+                     Watermark="Write your pattern and press enter..." />
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal">
+                <ToggleButton ToolTip.Tip="Search Up"
+                              Padding="5"
+                              IsChecked="{Binding SearchUp}"
+                              Focusable="False">
+                    <Viewbox Width="16"
+                             Height="16"
+                             HorizontalAlignment="Center">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                                  Data="{StaticResource SearchUpIcon}" />
                         </Canvas>
                     </Viewbox>
                 </ToggleButton>
-                <ToggleButton ToolTip="Match Whole Word" Padding="5" IsChecked="{Binding WholeWord}" Focusable="False"
-                              Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarToggleButton}}">
-                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource WholeWordIcon}" />
+                <ToggleButton ToolTip.Tip="Match Whole Word"
+                              Padding="5"
+                              IsChecked="{Binding WholeWord}"
+                              Focusable="False">
+                    <Viewbox Width="16"
+                             Height="16"
+                             HorizontalAlignment="Center">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                                  Data="{StaticResource WholeWordIcon}" />
                         </Canvas>
                     </Viewbox>
                 </ToggleButton>
-                <ToggleButton ToolTip="Match Case" Padding="5" IsChecked="{Binding CaseSensitive}" Focusable="False"
-                              Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarToggleButton}}">
-                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource MatchCaseIcon}" />
+                <ToggleButton ToolTip.Tip="Match Case"
+                              Padding="5"
+                              IsChecked="{Binding CaseSensitive}"
+                              Focusable="False">
+                    <Viewbox Width="16"
+                             Height="16"
+                             HorizontalAlignment="Center">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                                  Data="{StaticResource MatchCaseIcon}" />
                         </Canvas>
                     </Viewbox>
                 </ToggleButton>
-                <ToggleButton ToolTip="Regex" Padding="5" IsChecked="{Binding UseRegEx}" Focusable="False"
-                              Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarToggleButton}}">
-                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource RegexIcon}" />
+                <ToggleButton ToolTip.Tip="Regex"
+                              Padding="5"
+                              IsChecked="{Binding UseRegEx}"
+                              Focusable="False">
+                    <Viewbox Width="16"
+                             Height="16"
+                             HorizontalAlignment="Center">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                                  Data="{StaticResource RegexIcon}" />
                         </Canvas>
                     </Viewbox>
                 </ToggleButton>
-                <Button ToolTip="Clear Search Filter" Padding="5" Focusable="False" Click="OnDeleteSearchClick"
-                        Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}">
-                    <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                        <Canvas Width="24" Height="24">
-                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource BackspaceIcon}"/>
+                <Button ToolTip.Tip="Clear Search Filter"
+                        Padding="5"
+                        Focusable="False"
+                        Click="OnDeleteSearchClick">
+                    <Viewbox Width="16"
+                             Height="16"
+                             HorizontalAlignment="Center">
+                        <Canvas Width="24"
+                                Height="24">
+                            <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                                  Data="{StaticResource BackspaceIcon}" />
                         </Canvas>
                     </Viewbox>
                 </Button>
             </StackPanel>
-            <Button Grid.Column="2" ToolTip="Close" Padding="5" Focusable="False" Click="OnCloseClick" Margin="2 0 0 0"
-                    Style="{DynamicResource {x:Static adonisUi:Styles.ToolbarButton}}" BorderThickness="1"
-                    Background="{DynamicResource {x:Static adonisUi:Brushes.Layer3BackgroundBrush}}"
-                    BorderBrush="{DynamicResource {x:Static adonisUi:Brushes.AccentBrush}}">
-                <Viewbox Width="16" Height="16" HorizontalAlignment="Center">
-                    <Canvas Width="24" Height="24">
-                        <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource CloseIcon}"/>
+            <Button Grid.Column="2"
+                    ToolTip.Tip="Close"
+                    Padding="5"
+                    Focusable="False"
+                    Click="OnCloseClick"
+                    Margin="2 0 0 0"
+                    BorderThickness="1">
+                <Viewbox Width="16"
+                         Height="16"
+                         HorizontalAlignment="Center">
+                    <Canvas Width="24"
+                            Height="24">
+                        <Path Fill="{DynamicResource ThemeForegroundBrush}"
+                              Data="{StaticResource CloseIcon}" />
                     </Canvas>
                 </Viewbox>
             </Button>
         </Grid>
 
-        <avalonEdit:TextEditor x:Name="MyAvalonEditor" Grid.Row="0" Grid.RowSpan="2" SyntaxHighlighting="{Binding Highlighter}" Document="{Binding Document}"
-                               FontFamily="Consolas" FontSize="{Binding FontSize}" IsReadOnly="True" ShowLineNumbers="True" Foreground="#DAE5F2"
-                               Background="{DynamicResource {x:Static adonisUi:Brushes.Layer3BackgroundBrush}}" PreviewMouseWheel="OnPreviewMouseWheel"
-                               TextChanged="OnTextChanged" MouseHover="OnMouseHover" MouseHoverStopped="OnMouseHoverStopped" PreviewMouseUp="OnMouseRelease" />
+        <!-- TextEditor spans both rows; the search panel overlays Row 0 via ZIndex when open. -->
+        <avalonEdit:TextEditor x:Name="MyAvalonEditor"
+                               Grid.Row="0"
+                               Grid.RowSpan="2"
+                               SyntaxHighlighting="{Binding Highlighter}"
+                               Document="{Binding Document}"
+                               FontFamily="Consolas"
+                               FontSize="{Binding FontSize}"
+                               IsReadOnly="True"
+                               ShowLineNumbers="True"
+                               Foreground="#DAE5F2" />
     </Grid>
 </UserControl>

--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:avalonEdit="https://github.com/avaloniaui/avaloniaedit"
-             KeyDown="OnPreviewKeyDown">
+             KeyDown="OnKeyDown">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
@@ -12,6 +12,7 @@ using FModel.Services;
 using FModel.ViewModels;
 using AvaloniaEdit;
 using SkiaSharp;
+using VmTabItem = FModel.ViewModels.TabItem;
 
 namespace FModel.Views.Resources.Controls;
 
@@ -25,6 +26,9 @@ public partial class AvalonEditor
     private readonly Regex _hexColorRegex = new("\"Hex\": \"(?'target'[0-9A-Fa-f]{3,8})\"$",
         RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private readonly Dictionary<string, NavigationList<int>> _savedCarets = new();
+    // Cached tooltip controls — reused across hover events to avoid per-hover allocations.
+    private readonly TextBlock _hoverText = new();
+    private readonly Border _hoverBorder;
     private NavigationList<int> _caretsOffsets
     {
         get => MyAvalonEditor.Document != null && MyAvalonEditor.Document.FileName != null
@@ -52,21 +56,29 @@ public partial class AvalonEditor
         MyAvalonEditor.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
         MyAvalonEditor.PointerReleased += OnPointerReleased;
 
+        _hoverBorder = new Border
+        {
+            BorderThickness = new Avalonia.Thickness(1),
+            Padding = new Avalonia.Thickness(6, 4),
+            Child = _hoverText
+        };
+        ToolTip.SetTip(MyAvalonEditor, _hoverBorder);
+
         ApplicationService.ApplicationView.CUE4Parse.TabControl.OnTabRemove += OnTabClose;
     }
 
-    private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
+    private void OnKeyDown(object? sender, KeyEventArgs e)
     {
         switch (e.Key)
         {
             case Key.Escape:
-                ((TabItem) DataContext).HasSearchOpen = false;
+                ((VmTabItem) DataContext).HasSearchOpen = false;
                 break;
-            case Key.Enter when !e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((TabItem) DataContext).HasSearchOpen:
+            case Key.Enter when !e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((VmTabItem) DataContext).HasSearchOpen:
                 FindNext();
                 break;
-            case Key.Enter when e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((TabItem) DataContext).HasSearchOpen:
-                var dc = (TabItem) DataContext;
+            case Key.Enter when e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((VmTabItem) DataContext).HasSearchOpen:
+                var dc = (VmTabItem) DataContext;
                 var old = dc.SearchUp;
                 dc.SearchUp = true;
                 FindNext();
@@ -102,14 +114,10 @@ public partial class AvalonEditor
         var color = SKColor.Parse(g.Value);
         var bg = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
         IBrush fg = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
-        ToolTip.SetTip(MyAvalonEditor, new Border
-        {
-            Background = bg,
-            BorderBrush = fg,
-            BorderThickness = new Avalonia.Thickness(1),
-            Padding = new Avalonia.Thickness(6, 4),
-            Child = new TextBlock { Text = $"#{g.Value}", Foreground = fg }
-        });
+        _hoverBorder.Background = bg;
+        _hoverBorder.BorderBrush = fg;
+        _hoverText.Text = $"#{g.Value}";
+        _hoverText.Foreground = fg;
         ToolTip.SetIsOpen(MyAvalonEditor, true);
         e.Handled = true;
     }
@@ -129,7 +137,7 @@ public partial class AvalonEditor
 
     private void OnTextChanged(object? sender, EventArgs e)
     {
-        if (sender is not TextEditor avalonEditor || DataContext is not TabItem tabItem ||
+        if (sender is not TextEditor avalonEditor || DataContext is not VmTabItem tabItem ||
             avalonEditor.Document == null || string.IsNullOrEmpty(avalonEditor.Document.Text))
             return;
         avalonEditor.Document.FileName = tabItem.Entry.PathWithoutExtension;
@@ -151,7 +159,7 @@ public partial class AvalonEditor
 
     private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        if (DataContext is not TabItem tabItem || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        if (DataContext is not VmTabItem tabItem || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
             return;
 
         var fontSize = tabItem.FontSize + e.Delta.Y * 2.4;
@@ -165,12 +173,12 @@ public partial class AvalonEditor
 
     private void OnDeleteSearchClick(object? sender, RoutedEventArgs e)
     {
-        ((TabItem) DataContext).TextToFind = string.Empty;
+        ((VmTabItem) DataContext).TextToFind = string.Empty;
     }
 
     private void FindNext(bool invertLeftRight = false)
     {
-        var viewModel = (TabItem) DataContext;
+        var viewModel = (VmTabItem) DataContext;
         if (viewModel.Document == null || string.IsNullOrEmpty(viewModel.TextToFind))
             return;
 
@@ -212,7 +220,7 @@ public partial class AvalonEditor
     {
         Regex r;
         var o = RegexOptions.None;
-        var viewModel = (TabItem) DataContext;
+        var viewModel = (VmTabItem) DataContext;
 
         if (viewModel.SearchUp && !forceLeftToRight)
             o |= RegexOptions.RightToLeft;
@@ -237,7 +245,7 @@ public partial class AvalonEditor
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)
     {
-        ((TabItem) DataContext).HasSearchOpen = false;
+        ((VmTabItem) DataContext).HasSearchOpen = false;
     }
 
     private void OnTabClose(object sender, EventArgs eventArgs)

--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Windows;
-using System.Windows.Input;
-using System.Windows.Media;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
 using CUE4Parse.Utils;
 using FModel.Extensions;
 using FModel.Framework;
 using FModel.Services;
 using FModel.ViewModels;
-using ICSharpCode.AvalonEdit;
+using AvaloniaEdit;
 using SkiaSharp;
 
 namespace FModel.Views.Resources.Controls;
@@ -20,10 +21,9 @@ namespace FModel.Views.Resources.Controls;
 public partial class AvalonEditor
 {
     public static TextEditor YesWeEditor;
-    public static System.Windows.Controls.TextBox YesWeSearch;
+    public static TextBox YesWeSearch;
     private readonly Regex _hexColorRegex = new("\"Hex\": \"(?'target'[0-9A-Fa-f]{3,8})\"$",
         RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    private readonly System.Windows.Controls.ToolTip _toolTip = new();
     private readonly Dictionary<string, NavigationList<int>> _savedCarets = new();
     private NavigationList<int> _caretsOffsets
     {
@@ -35,7 +35,6 @@ public partial class AvalonEditor
 
     public AvalonEditor()
     {
-        CommandBindings.Add(new CommandBinding(NavigationCommands.Search, (_, e) => FindNext(e.Parameter != null)));
         InitializeComponent();
 
         YesWeEditor = MyAvalonEditor;
@@ -46,65 +45,78 @@ public partial class AvalonEditor
         MyAvalonEditor.TextArea.TextView.ElementGenerators.Add(new JumpElementGenerator());
         MyAvalonEditor.TextArea.TextView.ElementGenerators.Add(new HexColorElementGenerator());
 
+        // Events that were XAML-bound in WPF are wired here to use Avalonia's event model.
+        MyAvalonEditor.TextChanged += OnTextChanged;
+        MyAvalonEditor.TextArea.TextView.PointerHover += OnMouseHover;
+        MyAvalonEditor.TextArea.TextView.PointerHoverStopped += OnMouseHoverStopped;
+        MyAvalonEditor.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
+        MyAvalonEditor.PointerReleased += OnPointerReleased;
+
         ApplicationService.ApplicationView.CUE4Parse.TabControl.OnTabRemove += OnTabClose;
     }
 
-    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
     {
         switch (e.Key)
         {
             case Key.Escape:
                 ((TabItem) DataContext).HasSearchOpen = false;
                 break;
-            case Key.Enter when !Keyboard.Modifiers.HasFlag(ModifierKeys.Shift) && ((TabItem) DataContext).HasSearchOpen:
+            case Key.Enter when !e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((TabItem) DataContext).HasSearchOpen:
                 FindNext();
                 break;
-            case Key.Enter when Keyboard.Modifiers.HasFlag(ModifierKeys.Shift) && ((TabItem) DataContext).HasSearchOpen:
+            case Key.Enter when e.KeyModifiers.HasFlag(KeyModifiers.Shift) && ((TabItem) DataContext).HasSearchOpen:
                 var dc = (TabItem) DataContext;
                 var old = dc.SearchUp;
                 dc.SearchUp = true;
                 FindNext();
                 dc.SearchUp = old;
                 break;
-            case Key.System: // Alt
-                if (Keyboard.IsKeyDown(Key.Left))
-                {
-                    if (_caretsOffsets.Count == 0) return;
-                    MyAvalonEditor.CaretOffset = _caretsOffsets.MovePrevious;
-                    MyAvalonEditor.TextArea.Caret.BringCaretToView();
-                }
-                else if (Keyboard.IsKeyDown(Key.Right))
-                {
-                    if (_caretsOffsets.Count == 0) return;
-                    MyAvalonEditor.CaretOffset = _caretsOffsets.MoveNext;
-                    MyAvalonEditor.TextArea.Caret.BringCaretToView();
-                }
-
+            // Alt+Left / Alt+Right — navigate backward/forward through saved caret positions.
+            case Key.Left when e.KeyModifiers.HasFlag(KeyModifiers.Alt):
+                if (_caretsOffsets.Count == 0)
+                    return;
+                MyAvalonEditor.CaretOffset = _caretsOffsets.MovePrevious;
+                MyAvalonEditor.TextArea.Caret.BringCaretToView();
+                break;
+            case Key.Right when e.KeyModifiers.HasFlag(KeyModifiers.Alt):
+                if (_caretsOffsets.Count == 0)
+                    return;
+                MyAvalonEditor.CaretOffset = _caretsOffsets.MoveNext;
+                MyAvalonEditor.TextArea.Caret.BringCaretToView();
                 break;
         }
     }
 
-    private void OnMouseHover(object sender, MouseEventArgs e)
+    private void OnMouseHover(object? sender, PointerEventArgs e)
     {
         var pos = MyAvalonEditor.GetPositionFromPoint(e.GetPosition(MyAvalonEditor));
-        if (pos == null) return;
+        if (pos == null)
+            return;
 
         var line = MyAvalonEditor.Document.GetLineByNumber(pos.Value.Line);
         var m = _hexColorRegex.Match(MyAvalonEditor.Document.GetText(line.Offset, line.Length));
-        if (!m.Success || !m.Groups.TryGetValue("target", out var g)) return;
+        if (!m.Success || !m.Groups.TryGetValue("target", out var g))
+            return;
 
         var color = SKColor.Parse(g.Value);
-        _toolTip.PlacementTarget = this; // required for property inheritance
-        _toolTip.Background = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
-        _toolTip.Foreground = _toolTip.BorderBrush = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
-        _toolTip.Content = $"#{g.Value}";
-        _toolTip.IsOpen = true;
+        var bg = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
+        IBrush fg = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
+        ToolTip.SetTip(MyAvalonEditor, new Border
+        {
+            Background = bg,
+            BorderBrush = fg,
+            BorderThickness = new Avalonia.Thickness(1),
+            Padding = new Avalonia.Thickness(6, 4),
+            Child = new TextBlock { Text = $"#{g.Value}", Foreground = fg }
+        });
+        ToolTip.SetIsOpen(MyAvalonEditor, true);
         e.Handled = true;
     }
 
-    private void OnMouseHoverStopped(object sender, MouseEventArgs e)
+    private void OnMouseHoverStopped(object? sender, PointerEventArgs e)
     {
-        _toolTip.IsOpen = false;
+        ToolTip.SetIsOpen(MyAvalonEditor, false);
     }
 
     private int PerceivedBrightness(SKColor c)
@@ -115,7 +127,7 @@ public partial class AvalonEditor
             c.Blue * c.Blue * .114);
     }
 
-    private void OnTextChanged(object sender, EventArgs e)
+    private void OnTextChanged(object? sender, EventArgs e)
     {
         if (sender is not TextEditor avalonEditor || DataContext is not TabItem tabItem ||
             avalonEditor.Document == null || string.IsNullOrEmpty(avalonEditor.Document.Text))
@@ -125,22 +137,24 @@ public partial class AvalonEditor
         if (!_savedCarets.ContainsKey(avalonEditor.Document.FileName))
             _ignoreCaret = true;
 
-        if (!tabItem.ShouldScroll) return;
+        if (!tabItem.ShouldScroll)
+            return;
 
         var lineNumber = avalonEditor.Document.Text.GetNameLineNumber(tabItem.ScrollTrigger);
-        if (lineNumber == -1) lineNumber = 1;
+        if (lineNumber == -1)
+            lineNumber = 1;
 
         var line = avalonEditor.Document.GetLineByNumber(lineNumber);
         avalonEditor.Select(line.Offset, line.Length);
         avalonEditor.ScrollToLine(lineNumber);
     }
 
-    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        if (DataContext is not TabItem tabItem || Keyboard.Modifiers != ModifierKeys.Control)
+        if (DataContext is not TabItem tabItem || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
             return;
 
-        var fontSize = tabItem.FontSize + e.Delta / 50.0;
+        var fontSize = tabItem.FontSize + e.Delta.Y * 2.4;
         tabItem.FontSize = fontSize switch
         {
             < 6 => 6,
@@ -149,7 +163,7 @@ public partial class AvalonEditor
         };
     }
 
-    private void OnDeleteSearchClick(object sender, RoutedEventArgs e)
+    private void OnDeleteSearchClick(object? sender, RoutedEventArgs e)
     {
         ((TabItem) DataContext).TextToFind = string.Empty;
     }
@@ -167,7 +181,8 @@ public partial class AvalonEditor
             r = GetRegEx();
             viewModel.SearchUp = !viewModel.SearchUp;
         }
-        else r = GetRegEx();
+        else
+            r = GetRegEx();
 
         var rightToLeft = r.Options.HasFlag(RegexOptions.RightToLeft);
         var m = r.Match(MyAvalonEditor.Text, rightToLeft ? MyAvalonEditor.SelectionStart : MyAvalonEditor.SelectionStart + MyAvalonEditor.SelectionLength);
@@ -184,7 +199,8 @@ public partial class AvalonEditor
             do
             {
                 m = rightToLeft ? r.Match(MyAvalonEditor.Text, MyAvalonEditor.Text.Length - 1) : r.Match(MyAvalonEditor.Text, 0);
-                if (!m.Success) continue;
+                if (!m.Success)
+                    continue;
                 MyAvalonEditor.Select(m.Index, m.Length);
                 MyAvalonEditor.TextArea.Caret.BringCaretToView();
                 break;
@@ -219,7 +235,7 @@ public partial class AvalonEditor
         return r;
     }
 
-    private void OnCloseClick(object sender, RoutedEventArgs e)
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
     {
         ((TabItem) DataContext).HasSearchOpen = false;
     }
@@ -250,7 +266,7 @@ public partial class AvalonEditor
         }
     }
 
-    private void OnMouseRelease(object sender, MouseButtonEventArgs e)
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         SaveCaretLoc(MyAvalonEditor.CaretOffset);
     }

--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
@@ -169,6 +169,7 @@ public partial class AvalonEditor
             > 200 => 200,
             _ => fontSize
         };
+        e.Handled = true; // prevent scroll-through to the document
     }
 
     private void OnDeleteSearchClick(object? sender, RoutedEventArgs e)

--- a/FModel/Views/Resources/Controls/DictionaryEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/DictionaryEditor.xaml.cs
@@ -5,7 +5,7 @@ using System.Windows.Media;
 using CUE4Parse.UE4.Objects.Core.Misc;
 using CUE4Parse.UE4.Objects.Core.Serialization;
 using FModel.Extensions;
-using ICSharpCode.AvalonEdit.Document;
+using AvaloniaEdit.Document;
 using Newtonsoft.Json;
 
 namespace FModel.Views.Resources.Controls;

--- a/FModel/Views/Resources/Controls/EndpointEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/EndpointEditor.xaml.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 using FModel.Extensions;
 using FModel.Services;
 using FModel.Settings;
-using ICSharpCode.AvalonEdit.Document;
+using AvaloniaEdit.Document;
 using Newtonsoft.Json;
 
 namespace FModel.Views.Resources.Controls;
@@ -56,7 +56,8 @@ public partial class EndpointEditor
 
     private async void OnSend(object sender, RoutedEventArgs e)
     {
-        if (DataContext is not EndpointSettings endpoint) return;
+        if (DataContext is not EndpointSettings endpoint)
+            return;
 
         var body = await ApplicationService.ApiEndpointView.DynamicApi.GetRequestBody(default, endpoint.Url).ConfigureAwait(false);
         Application.Current.Dispatcher.Invoke(delegate
@@ -68,7 +69,8 @@ public partial class EndpointEditor
 
     private void OnTest(object sender, RoutedEventArgs e)
     {
-        if (DataContext is not EndpointSettings endpoint) return;
+        if (DataContext is not EndpointSettings endpoint)
+            return;
 
         endpoint.TryValidate(ApplicationService.ApiEndpointView.DynamicApi, _type, out var response);
         _isTested = true;
@@ -80,7 +82,8 @@ public partial class EndpointEditor
     private void OnTextChanged(object sender, TextChangedEventArgs e)
     {
         if (sender is not TextBox { IsLoaded: true } ||
-            DataContext is not EndpointSettings endpoint) return;
+            DataContext is not EndpointSettings endpoint)
+            return;
         endpoint.IsValid = false;
     }
 

--- a/FModel/Views/Resources/Controls/PropertiesPopout.xaml
+++ b/FModel/Views/Resources/Controls/PropertiesPopout.xaml
@@ -1,15 +1,16 @@
-﻿<adonisControls:AdonisWindow x:Class="FModel.Views.Resources.Controls.PropertiesPopout"
-         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:converters="clr-namespace:FModel.Views.Resources.Converters"
-         xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
-         xmlns:adonisUi="clr-namespace:AdonisUI;assembly=AdonisUI"
-         xmlns:adonisControls="clr-namespace:AdonisUI.Controls;assembly=AdonisUI"
-         WindowStartupLocation="CenterScreen" IconVisibility="Collapsed" PreviewKeyDown="OnPreviewKeyDown"
-         Width="{Binding Source={x:Static SystemParameters.MaximizedPrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.40'}">
-    <DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-        <avalonEdit:TextEditor x:Name="MyAvalonEditor" Background="{DynamicResource {x:Static adonisUi:Brushes.Layer3BackgroundBrush}}"
-                               FontFamily="Consolas" FontSize="8pt" IsReadOnly="True" ShowLineNumbers="True" Foreground="#DAE5F2"
-                               MouseHover="OnMouseHover" MouseHoverStopped="OnMouseHoverStopped" PreviewMouseWheel="OnPreviewMouseWheel" />
-    </DockPanel>
-</adonisControls:AdonisWindow>
+﻿<Window x:Class="FModel.Views.Resources.Controls.PropertiesPopout"
+        xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:avalonEdit="https://github.com/avaloniaui/avaloniaedit"
+        WindowStartupLocation="CenterScreen"
+        Width="800"
+        KeyDown="OnKeyDown">
+    <!-- PointerHover/PointerHoverStopped and PointerWheelChangedEvent are wired in code-behind
+         because they live on TextArea.TextView, not directly on TextEditor. -->
+    <avalonEdit:TextEditor x:Name="MyAvalonEditor"
+                           FontFamily="Consolas"
+                           FontSize="10.67"
+                           IsReadOnly="True"
+                           ShowLineNumbers="True"
+                           Foreground="#DAE5F2" />
+</Window>

--- a/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
@@ -91,6 +91,7 @@ public partial class PropertiesPopout
             > 200 => 200,
             _ => fontSize
         };
+        e.Handled = true; // prevent scroll-through to the document
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)

--- a/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using CUE4Parse.Utils;
 using FModel.ViewModels;
@@ -17,7 +18,11 @@ public partial class PropertiesPopout
         RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private JsonFoldingStrategies _manager;
 
-    public PropertiesPopout(ViewModels.TabItem contextViewModel)
+    // Cached tooltip controls — reused across hover events to avoid per-hover allocations.
+    private readonly TextBlock _hoverText = new();
+    private readonly Border _hoverBorder;
+
+    public PropertiesPopout(FModel.ViewModels.TabItem contextViewModel)
     {
         InitializeComponent();
 
@@ -36,6 +41,19 @@ public partial class PropertiesPopout
         MyAvalonEditor.TextArea.TextView.ElementGenerators.Add(new HexColorElementGenerator());
         _manager = new JsonFoldingStrategies(MyAvalonEditor);
         _manager.UpdateFoldings(MyAvalonEditor.Document);
+
+        // Wire events that cannot be bound in XAML because they live on TextView, not TextEditor.
+        MyAvalonEditor.TextArea.TextView.PointerHover += OnMouseHover;
+        MyAvalonEditor.TextArea.TextView.PointerHoverStopped += OnMouseHoverStopped;
+        MyAvalonEditor.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
+
+        _hoverBorder = new Border
+        {
+            BorderThickness = new Avalonia.Thickness(1),
+            Padding = new Avalonia.Thickness(6, 4),
+            Child = _hoverText
+        };
+        ToolTip.SetTip(MyAvalonEditor, _hoverBorder);
     }
 
     private void OnMouseHover(object? sender, PointerEventArgs e)
@@ -52,14 +70,10 @@ public partial class PropertiesPopout
         var color = SKColor.Parse(g.Value);
         var bg = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
         IBrush fg = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
-        ToolTip.SetTip(MyAvalonEditor, new Border
-        {
-            Background = bg,
-            BorderBrush = fg,
-            BorderThickness = new Avalonia.Thickness(1),
-            Padding = new Avalonia.Thickness(6, 4),
-            Child = new TextBlock { Text = $"#{g.Value}", Foreground = fg }
-        });
+        _hoverBorder.Background = bg;
+        _hoverBorder.BorderBrush = fg;
+        _hoverText.Text = $"#{g.Value}";
+        _hoverText.Foreground = fg;
         ToolTip.SetIsOpen(MyAvalonEditor, true);
         e.Handled = true;
     }
@@ -79,7 +93,7 @@ public partial class PropertiesPopout
         };
     }
 
-    private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
+    private void OnKeyDown(object? sender, KeyEventArgs e)
     {
         switch (e.Key)
         {

--- a/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
+++ b/FModel/Views/Resources/Controls/PropertiesPopout.xaml.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Text.RegularExpressions;
-using System.Windows.Input;
-using System.Windows.Media;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
 using CUE4Parse.Utils;
 using FModel.ViewModels;
-using ICSharpCode.AvalonEdit;
-using ICSharpCode.AvalonEdit.Document;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
 using SkiaSharp;
 
 namespace FModel.Views.Resources.Controls;
@@ -14,10 +15,9 @@ public partial class PropertiesPopout
 {
     private readonly Regex _hexColorRegex = new("\"Hex\": \"(?'target'[0-9A-Fa-f]{3,8})\"$",
         RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    private readonly System.Windows.Controls.ToolTip _toolTip = new();
     private JsonFoldingStrategies _manager;
 
-    public PropertiesPopout(TabItem contextViewModel)
+    public PropertiesPopout(ViewModels.TabItem contextViewModel)
     {
         InitializeComponent();
 
@@ -38,30 +38,38 @@ public partial class PropertiesPopout
         _manager.UpdateFoldings(MyAvalonEditor.Document);
     }
 
-    private void OnMouseHover(object sender, MouseEventArgs e)
+    private void OnMouseHover(object? sender, PointerEventArgs e)
     {
         var pos = MyAvalonEditor.GetPositionFromPoint(e.GetPosition(MyAvalonEditor));
-        if (pos == null) return;
+        if (pos == null)
+            return;
 
         var line = MyAvalonEditor.Document.GetLineByNumber(pos.Value.Line);
         var m = _hexColorRegex.Match(MyAvalonEditor.Document.GetText(line.Offset, line.Length));
-        if (!m.Success || !m.Groups.TryGetValue("target", out var g)) return;
+        if (!m.Success || !m.Groups.TryGetValue("target", out var g))
+            return;
 
         var color = SKColor.Parse(g.Value);
-        _toolTip.PlacementTarget = this; // required for property inheritance
-        _toolTip.Background = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
-        _toolTip.Foreground = _toolTip.BorderBrush = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
-        _toolTip.Content = $"#{g.Value}";
-        _toolTip.IsOpen = true;
+        var bg = new SolidColorBrush(Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue));
+        IBrush fg = PerceivedBrightness(color) > 130 ? Brushes.Black : Brushes.White;
+        ToolTip.SetTip(MyAvalonEditor, new Border
+        {
+            Background = bg,
+            BorderBrush = fg,
+            BorderThickness = new Avalonia.Thickness(1),
+            Padding = new Avalonia.Thickness(6, 4),
+            Child = new TextBlock { Text = $"#{g.Value}", Foreground = fg }
+        });
+        ToolTip.SetIsOpen(MyAvalonEditor, true);
         e.Handled = true;
     }
 
-    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        if (sender is not TextEditor avalonEditor || Keyboard.Modifiers != ModifierKeys.Control)
+        if (sender is not TextEditor avalonEditor || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
             return;
 
-        var fontSize = avalonEditor.FontSize + e.Delta / 50.0;
+        var fontSize = avalonEditor.FontSize + e.Delta.Y * 2.4;
 
         avalonEditor.FontSize = fontSize switch
         {
@@ -71,25 +79,25 @@ public partial class PropertiesPopout
         };
     }
 
-    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
     {
         switch (e.Key)
         {
-            case Key.J when Keyboard.IsKeyDown(Key.K) && Keyboard.Modifiers.HasFlag(ModifierKeys.Control):
+            case Key.J when e.KeyModifiers.HasFlag(KeyModifiers.Control):
                 _manager.UnfoldAll();
                 break;
-            case Key.L when Keyboard.IsKeyDown(Key.K) && Keyboard.Modifiers.HasFlag(ModifierKeys.Control):
+            case Key.L when e.KeyModifiers.HasFlag(KeyModifiers.Control):
                 _manager.FoldToggle(MyAvalonEditor.CaretOffset);
                 break;
-            case >= Key.D0 and <= Key.D9 when Keyboard.IsKeyDown(Key.K) && Keyboard.Modifiers.HasFlag(ModifierKeys.Control):
+            case >= Key.D0 and <= Key.D9 when e.KeyModifiers.HasFlag(KeyModifiers.Control):
                 _manager.FoldToggleAtLevel(int.Parse(e.Key.ToString()[1].ToString()));
                 break;
         }
     }
 
-    private void OnMouseHoverStopped(object sender, MouseEventArgs e)
+    private void OnMouseHoverStopped(object? sender, PointerEventArgs e)
     {
-        _toolTip.IsOpen = false;
+        ToolTip.SetIsOpen(MyAvalonEditor, false);
     }
 
     private int PerceivedBrightness(SKColor c)


### PR DESCRIPTION
## Summary

Resolves #28 — replaces all `ICSharpCode.AvalonEdit.*` references with `AvaloniaEdit.*` (the cross-platform Avalonia port), making the text editor components work on Linux/macOS without WPF.

The `Avalonia.AvaloniaEdit` 11.3.0 package was already present in `FModel.csproj`; this PR activates it by updating all usages.

---

## Files Changed

### Namespace-only migration (9 files)
- `Extensions/AvalonExtensions.cs`
- `Extensions/StringExtensions.cs`
- `ViewModels/TabControlViewModel.cs`  *(AvalonEdit usings only; BitmapImage/Dispatcher are a separate ticket)*
- `Views/Resources/Controls/EndpointEditor.xaml.cs`  *(AvalonEdit using only)*
- `Views/Resources/Controls/DictionaryEditor.xaml.cs`  *(AvalonEdit using only)*
- `Views/Resources/Controls/Aed/HexColorElementGenerator.cs`
- `Views/Resources/Controls/Aed/GamePathElementGenerator.cs`
- `Views/Resources/Controls/Aed/JumpElementGenerator.cs`
- `Views/Resources/Controls/Aed/BraceFoldingStrategy.cs`

### Full API migration (6 files)

**`Aed/HexColorVisualLineText.cs`**
- Add `Avalonia.Media.TextFormatting` for `TextRun` return type
- `CreateTextRun`: use `base.CreateTextRun()` + `TextRunProperties.SetForegroundBrush()`
- Remove `OnQueryCursor` (no Avalonia equivalent; cursor UX enhancement only)

**`Aed/GamePathVisualLineText.cs`** / **`Aed/JumpVisualLineText.cs`**
- Same `CreateTextRun` pattern as above
- `OnMouseDown(MouseButtonEventArgs)` → `OnPointerPressed(PointerPressedEventArgs)`
- `Keyboard.Modifiers` → `e.KeyModifiers` passed as parameter
- Remove `OnQueryCursor`

**`Views/Resources/Controls/PropertiesPopout.xaml.cs`**
- `System.Windows.Controls.ToolTip` field removed
- `MouseEventArgs` → `PointerEventArgs` for hover events
- `OnPreviewMouseWheel` → `OnPointerWheelChanged(PointerWheelEventArgs)` with `e.Delta.Y * 2.4` (maps 120-unit WPF ticks to Avalonia ~1.0 ticks)
- WPF `ToolTip` → `ToolTip.SetTip(control, content)` + `ToolTip.SetIsOpen(control, bool)`
- Keyboard chord `Ctrl+K, J/L/0-9` simplified to `Ctrl+J/L/0-9` (no stateful key-chord API in Avalonia)
- Qualify `FModel.ViewModels.TabItem` to avoid ambiguity with `Avalonia.Controls.TabItem`

**`Views/Resources/Controls/AvalonEditor.xaml`**
- Namespaces: `http://schemas.microsoft.com/winfx/...` → `https://github.com/avaloniaui`; AdonisUI namespaces removed
- Search panel visibility: `DataTrigger`/ZIndex pattern → `IsVisible="{Binding HasSearchOpen}" ZIndex="1"`
- `adonisExtensions:WatermarkExtension.Watermark` → built-in `Watermark="..."` on `TextBox`
- AdonisUI `{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}` → `{DynamicResource ThemeForegroundBrush}`
- `ToolTip="..."` → `ToolTip.Tip="..."`
- XAML-bound events removed (all wired in constructor instead)

**`Views/Resources/Controls/AvalonEditor.xaml.cs`**
- Remove WPF `CommandBindings.Add(new CommandBinding(NavigationCommands.Search, ...))` (no equivalent)
- Events wired in constructor: `PointerHover`, `PointerHoverStopped`, `PointerWheelChangedEvent` (tunnel routing), `PointerReleased`
- `Key.System` (Alt detection) → `Key.Left/Right when e.KeyModifiers.HasFlag(KeyModifiers.Alt)`
- `OnPointerWheelChanged` with `PointerWheelEventArgs`
- WPF `ToolTip` → Avalonia `ToolTip.SetTip/SetIsOpen`

---

## Testing Notes

Build verified: all errors introduced by this migration are resolved. Remaining build errors in the project (e.g. `DictionaryEditor`, `EndpointEditor`, `TabControlViewModel` `System.Windows.*` usages; `AudioPlayerViewModel` CSCore references) are **pre-existing** on `dev` and are out of scope for this ticket.