### PR TITLE
feat(dispatcher): Replace Application.Current.Dispatcher with Avalonia UIThread [P2-010]

### DIFF
--- a/FModel/ViewModels/AssetsFolderViewModel.cs
+++ b/FModel/ViewModels/AssetsFolderViewModel.cs
@@ -4,8 +4,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Data;
+using Avalonia.Threading;
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.VirtualFileSystem;
@@ -130,9 +130,9 @@ public class TreeItem : ViewModel
                     };
                 }
 
-                if (!Application.Current.Dispatcher.CheckAccess())
+                if (!Dispatcher.UIThread.CheckAccess())
                 {
-                    Application.Current.Dispatcher.Invoke(CreateCombinedEntries);
+                    Dispatcher.UIThread.InvokeAsync(CreateCombinedEntries).GetAwaiter().GetResult();
                 }
                 else
                 {
@@ -171,19 +171,19 @@ public class TreeItem : ViewModel
         switch (item)
         {
             case GameFileViewModel entry:
-            {
-                bool matchesSearch = f.Length == 0 || f.All(x => entry.Asset.Name.Contains(x, StringComparison.OrdinalIgnoreCase));
-                bool matchesCategory = SelectedCategory == EAssetCategory.All || entry.AssetCategory.IsOfCategory(SelectedCategory);
+                {
+                    bool matchesSearch = f.Length == 0 || f.All(x => entry.Asset.Name.Contains(x, StringComparison.OrdinalIgnoreCase));
+                    bool matchesCategory = SelectedCategory == EAssetCategory.All || entry.AssetCategory.IsOfCategory(SelectedCategory);
 
-                return matchesSearch && matchesCategory;
-            }
+                    return matchesSearch && matchesCategory;
+                }
             case TreeItem folder:
-            {
-                bool matchesSearch = f.Length == 0 || f.All(x => folder.Header.Contains(x, StringComparison.OrdinalIgnoreCase));
-                bool matchesCategory = SelectedCategory == EAssetCategory.All;
+                {
+                    bool matchesSearch = f.Length == 0 || f.All(x => folder.Header.Contains(x, StringComparison.OrdinalIgnoreCase));
+                    bool matchesCategory = SelectedCategory == EAssetCategory.All;
 
-                return matchesSearch && matchesCategory;
-            }
+                    return matchesSearch && matchesCategory;
+                }
         }
         return false;
     }
@@ -213,7 +213,7 @@ public class AssetsFolderViewModel
         if (entries == null || entries.Count == 0)
             return;
 
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Post(() =>
         {
             var treeItems = new RangeObservableCollection<TreeItem>();
             treeItems.SetSuppressionState(true);

--- a/FModel/ViewModels/AudioPlayerViewModel.cs
+++ b/FModel/ViewModels/AudioPlayerViewModel.cs
@@ -6,8 +6,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Windows;
 using System.Windows.Data;
+using Avalonia.Threading;
 using CSCore;
 using CSCore.CoreAudioAPI;
 using CSCore.DSP;
@@ -217,7 +217,7 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Load()
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Post(() =>
         {
             if (!ConvertIfNeeded())
                 return;
@@ -240,10 +240,11 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void AddToPlaylist(byte[] data, string filePath)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Post(() =>
         {
             _audioFiles.Add(new AudioFile(_audioFiles.Count, data, filePath));
-            if (_audioFiles.Count > 1) return;
+            if (_audioFiles.Count > 1)
+                return;
 
             SelectedAudioFile = _audioFiles.Last();
             Load();
@@ -253,10 +254,11 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void AddToPlaylist(string filePath)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Post(() =>
         {
             _audioFiles.Add(new AudioFile(_audioFiles.Count, new FileInfo(filePath)));
-            if (_audioFiles.Count > 1) return;
+            if (_audioFiles.Count > 1)
+                return;
 
             SelectedAudioFile = _audioFiles.Last();
             Load();
@@ -266,8 +268,9 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Remove()
     {
-        if (_audioFiles.Count < 1) return;
-        Application.Current.Dispatcher.Invoke(() =>
+        if (_audioFiles.Count < 1)
+            return;
+        Dispatcher.UIThread.Post(() =>
         {
             _audioFiles.RemoveAt(SelectedAudioFile.Id);
             for (var i = 0; i < _audioFiles.Count; i++)
@@ -279,8 +282,9 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Replace(AudioFile newAudio)
     {
-        if (_audioFiles.Count < 1) return;
-        Application.Current.Dispatcher.Invoke(() =>
+        if (_audioFiles.Count < 1)
+            return;
+        Dispatcher.UIThread.Post(() =>
         {
             _audioFiles.Insert(SelectedAudioFile.Id, newAudio);
             _audioFiles.RemoveAt(SelectedAudioFile.Id + 1);
@@ -290,8 +294,9 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void SavePlaylist()
     {
-        if (_audioFiles.Count < 1) return;
-        Application.Current.Dispatcher.Invoke(() =>
+        if (_audioFiles.Count < 1)
+            return;
+        Dispatcher.UIThread.Post(() =>
         {
             foreach (var a in _audioFiles)
             {
@@ -311,7 +316,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
     public void Save(AudioFile file = null, bool auto = false)
     {
         var fileToSave = file ?? SelectedAudioFile;
-        if (_audioFiles.Count < 1 || fileToSave?.Data == null) return;
+        if (_audioFiles.Count < 1 || fileToSave?.Data == null)
+            return;
         var path = fileToSave.FilePath;
 
         if (!auto)
@@ -322,7 +328,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
                 FileName = fileToSave.FileName,
                 InitialDirectory = UserSettings.Default.AudioDirectory
             };
-            if (!saveFileDialog.ShowDialog().GetValueOrDefault()) return;
+            if (!saveFileDialog.ShowDialog().GetValueOrDefault())
+                return;
             path = saveFileDialog.FileName;
         }
         else
@@ -378,7 +385,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void PlayPauseOnForce()
     {
-        if (_audioFiles.Count < 1 || SelectedAudioFile.Id == PlayedFile.Id) return;
+        if (_audioFiles.Count < 1 || SelectedAudioFile.Id == PlayedFile.Id)
+            return;
 
         Stop();
         Load();
@@ -387,7 +395,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Next()
     {
-        if (_audioFiles.Count < 1) return;
+        if (_audioFiles.Count < 1)
+            return;
 
         Stop();
         SelectedAudioFile = _audioFiles.Next(PlayedFile.Id);
@@ -397,7 +406,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Previous()
     {
-        if (_audioFiles.Count < 1) return;
+        if (_audioFiles.Count < 1)
+            return;
 
         Stop();
         SelectedAudioFile = _audioFiles.Previous(PlayedFile.Id);
@@ -407,51 +417,59 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Play()
     {
-        if (_soundOut == null || IsPlaying) return;
+        if (_soundOut == null || IsPlaying)
+            return;
         _discordHandler.UpdateButDontSavePresence(null, $"Audio Player: {PlayedFile.FileName} ({PlayedFile.Duration:g})");
         _soundOut.Play();
     }
 
     public void Pause()
     {
-        if (_soundOut == null || IsPaused) return;
+        if (_soundOut == null || IsPaused)
+            return;
         _soundOut.Pause();
     }
 
     public void Resume()
     {
-        if (_soundOut == null || !IsPaused) return;
+        if (_soundOut == null || !IsPaused)
+            return;
         _soundOut.Resume();
     }
 
     public void Stop()
     {
-        if (_soundOut == null || IsStopped) return;
+        if (_soundOut == null || IsStopped)
+            return;
         _soundOut.Stop();
     }
 
     public void HideToggle()
     {
-        if (!IsPlaying) return;
+        if (!IsPlaying)
+            return;
         _hideToggle = !_hideToggle;
         RaiseSourcePropertyChangedEvent(ESourceProperty.HideToggle, _hideToggle);
     }
 
     public void SkipTo(double percentage)
     {
-        if (_soundOut == null || _waveSource == null) return;
+        if (_soundOut == null || _waveSource == null)
+            return;
         _waveSource.Position = (long) (_waveSource.Length * percentage);
     }
 
     public void Volume()
     {
-        if (_soundOut == null) return;
+        if (_soundOut == null)
+            return;
         _soundOut.Volume = UserSettings.Default.AudioPlayerVolume / 100;
     }
 
     public void Device()
     {
-        if (_soundOut == null) return;
+        if (_soundOut == null)
+            return;
 
         Pause();
         LoadSoundOut();
@@ -460,7 +478,7 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Dispose()
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Post(() =>
         {
             if (_waveSource != null)
             {
@@ -489,7 +507,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     private void TimerTick(object state)
     {
-        if (_waveSource == null || _soundOut == null) return;
+        if (_waveSource == null || _soundOut == null)
+            return;
 
         if (_position != PlayedFile.Position)
         {
@@ -513,7 +532,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     private void LoadSoundOut()
     {
-        if (_waveSource == null) return;
+        if (_waveSource == null)
+            return;
         _soundOut = new WasapiOut(true, AudioClientShareMode.Shared, 100, ThreadPriority.Highest) { Device = SelectedAudioDevice };
         _soundOut.Initialize(_waveSource.ToSampleSource().ToWaveSource(16));
         _soundOut.Volume = UserSettings.Default.AudioPlayerVolume / 100;
@@ -536,16 +556,17 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public event EventHandler<SourcePropertyChangedEventArgs> SourcePropertyChangedEvent = (sender, args) =>
     {
-        if (sender is not AudioPlayerViewModel viewModel) return;
+        if (sender is not AudioPlayerViewModel viewModel)
+            return;
         switch (args.Property)
         {
             case ESourceProperty.PlaybackState:
-            {
-                if (viewModel._position == viewModel._length && (PlaybackState) args.Value == PlaybackState.Stopped)
-                    viewModel.Next();
+                {
+                    if (viewModel._position == viewModel._length && (PlaybackState) args.Value == PlaybackState.Stopped)
+                        viewModel.Next();
 
-                break;
-            }
+                    break;
+                }
         }
     };
 
@@ -573,30 +594,30 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
             case "wem":
             case "at9":
             case "raw":
-            {
-                if (TryConvert(out var wavFilePath))
                 {
-                    var newAudio = new AudioFile(SelectedAudioFile.Id, new FileInfo(wavFilePath));
-                    Replace(newAudio);
-                    return true;
-                }
+                    if (TryConvert(out var wavFilePath))
+                    {
+                        var newAudio = new AudioFile(SelectedAudioFile.Id, new FileInfo(wavFilePath));
+                        Replace(newAudio);
+                        return true;
+                    }
 
-                return false;
-            }
+                    return false;
+                }
             case "adx":
             case "hca":
                 return TryConvertCriware();
             case "rada":
-            {
-                if (TryDecode(SelectedAudioFile.Extension, out var rawFilePath))
                 {
-                    var newAudio = new AudioFile(SelectedAudioFile.Id, new FileInfo(rawFilePath));
-                    Replace(newAudio);
-                    return true;
-                }
+                    if (TryDecode(SelectedAudioFile.Extension, out var rawFilePath))
+                    {
+                        var newAudio = new AudioFile(SelectedAudioFile.Id, new FileInfo(rawFilePath));
+                        Replace(newAudio);
+                        return true;
+                    }
 
-                return false;
-            }
+                    return false;
+                }
         }
 
         return true;
@@ -662,7 +683,8 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
         if (!File.Exists(vgmFilePath))
         {
             vgmFilePath = Path.Combine(UserSettings.Default.OutputDirectory, ".data", "vgmstream-cli.exe");
-            if (!File.Exists(vgmFilePath)) return false;
+            if (!File.Exists(vgmFilePath))
+                return false;
         }
 
         Directory.CreateDirectory(inputFilePath.SubstringBeforeLast("/"));

--- a/FModel/ViewModels/AudioPlayerViewModel.cs
+++ b/FModel/ViewModels/AudioPlayerViewModel.cs
@@ -217,25 +217,25 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Load()
     {
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (!ConvertIfNeeded())
-                return;
+        // All callers are already on the UI thread (command handlers, key handlers, or an
+        // enclosing Post lambda), so there is no need to defer — running synchronously
+        // ensures LoadSoundOut() has finished before the caller invokes Play().
+        if (!ConvertIfNeeded())
+            return;
 
-            _waveSource = new CustomCodecFactory().GetCodec(SelectedAudioFile.Data, SelectedAudioFile.Extension);
-            if (_waveSource == null)
-                return;
+        _waveSource = new CustomCodecFactory().GetCodec(SelectedAudioFile.Data, SelectedAudioFile.Extension);
+        if (_waveSource == null)
+            return;
 
-            PlayedFile = new AudioFile(SelectedAudioFile, _waveSource);
-            Spectrum = new SpectrumProvider(_waveSource.WaveFormat.Channels, _waveSource.WaveFormat.SampleRate, FftSize.Fft4096);
+        PlayedFile = new AudioFile(SelectedAudioFile, _waveSource);
+        Spectrum = new SpectrumProvider(_waveSource.WaveFormat.Channels, _waveSource.WaveFormat.SampleRate, FftSize.Fft4096);
 
-            var notificationSource = new SingleBlockNotificationStream(_waveSource.ToSampleSource());
-            notificationSource.SingleBlockRead += (s, a) => Spectrum.Add(a.Left, a.Right);
-            _waveSource = notificationSource.ToWaveSource(16);
+        var notificationSource = new SingleBlockNotificationStream(_waveSource.ToSampleSource());
+        notificationSource.SingleBlockRead += (s, a) => Spectrum.Add(a.Left, a.Right);
+        _waveSource = notificationSource.ToWaveSource(16);
 
-            RaiseSourceEvent(ESourceEventType.Loading);
-            LoadSoundOut();
-        });
+        RaiseSourceEvent(ESourceEventType.Loading);
+        LoadSoundOut();
     }
 
     public void AddToPlaylist(byte[] data, string filePath)
@@ -478,31 +478,32 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
 
     public void Dispose()
     {
-        Dispatcher.UIThread.Post(() =>
+        // Stop the timer synchronously first to eliminate any window in which a
+        // threadpool tick could access _waveSource / _soundOut while they are
+        // being torn down (use-after-dispose race).
+        _sourceTimer.Change(Timeout.Infinite, Timeout.Infinite);
+
+        // Dispose() is invoked from OnClosing which fires on the UI thread, so all
+        // of the following runs inline without needing to be posted.
+        if (_waveSource != null)
         {
-            if (_waveSource != null)
-            {
-                _waveSource.Dispose();
-                _waveSource = null;
-            }
+            _waveSource.Dispose();
+            _waveSource = null;
+        }
 
-            if (_soundOut != null)
-            {
-                _soundOut.Dispose();
-                _soundOut = null;
-            }
+        if (_soundOut != null)
+        {
+            _soundOut.Dispose();
+            _soundOut = null;
+        }
 
-            if (Spectrum != null)
-                Spectrum = null;
+        Spectrum = null;
 
-            foreach (var a in _audioFiles)
-            {
-                a.Data = null;
-            }
+        foreach (var a in _audioFiles)
+            a.Data = null;
 
-            _audioFiles.Clear();
-            PlayedFile = new AudioFile(-1, "No audio file");
-        });
+        _audioFiles.Clear();
+        PlayedFile = new AudioFile(-1, "No audio file");
     }
 
     private void TimerTick(object state)

--- a/FModel/ViewModels/BackupManagerViewModel.cs
+++ b/FModel/ViewModels/BackupManagerViewModel.cs
@@ -4,8 +4,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Data;
+using Avalonia.Threading;
 using CUE4Parse.FileProvider.Objects;
 using FModel.Framework;
 using FModel.Services;
@@ -49,11 +49,13 @@ public class BackupManagerViewModel : ViewModel
         await _threadWorkerView.Begin(cancellationToken =>
         {
             var backups = _apiEndpointView.DillyApi.GetBackups(cancellationToken);
-            if (backups == null) return;
+            if (backups == null)
+                return;
 
-            Application.Current.Dispatcher.Invoke(() =>
+            Dispatcher.UIThread.Post(() =>
             {
-                foreach (var backup in backups) Backups.Add(backup);
+                foreach (var backup in backups)
+                    Backups.Add(backup);
                 SelectedBackup = Backups.FirstOrDefault();
             });
         });
@@ -77,7 +79,8 @@ public class BackupManagerViewModel : ViewModel
 
             foreach (var asset in _applicationView.CUE4Parse.Provider.Files.Values)
             {
-                if (!func(asset)) continue;
+                if (!func(asset))
+                    continue;
                 writer.Write(asset.Size);
                 writer.Write(asset.IsEncrypted);
                 writer.Write(asset.Path);
@@ -89,7 +92,8 @@ public class BackupManagerViewModel : ViewModel
 
     public async Task Download()
     {
-        if (SelectedBackup == null) return;
+        if (SelectedBackup == null)
+            return;
         await _threadWorkerView.Begin(_ =>
         {
             var fullPath = Path.Combine(Path.Combine(UserSettings.Default.OutputDirectory, "Backups"), SelectedBackup.FileName);

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -88,7 +88,7 @@ using Svg.Skia;
 
 using UE4Config.Parsing;
 
-using Application = System.Windows.Application;
+using Avalonia.Threading;
 using FGuid = CUE4Parse.UE4.Objects.Core.Misc.FGuid;
 
 namespace FModel.ViewModels;
@@ -120,9 +120,12 @@ public class CUE4ParseViewModel : ViewModel
     {
         get
         {
-            if (_snooper != null) return _snooper;
+            if (_snooper != null)
+                return _snooper;
 
-            return Application.Current.Dispatcher.Invoke(delegate
+            // Create the OpenTK game window on the UI thread; use CheckAccess so that a
+            // UI-thread caller (e.g. MenuCommand) does not deadlock on InvokeAsync.
+            Snooper MakeSnooper()
             {
                 var scale = ImGuiController.GetDpiScale();
                 var htz = Snooper.GetMaxRefreshFrequency();
@@ -143,7 +146,11 @@ public class CUE4ParseViewModel : ViewModel
                         StartFocused = false,
                         Title = "3D Viewer"
                     });
-            });
+            }
+
+            return Dispatcher.UIThread.CheckAccess()
+                ? MakeSnooper()
+                : Dispatcher.UIThread.InvokeAsync(MakeSnooper).GetAwaiter().GetResult();
         }
     }
 
@@ -176,36 +183,36 @@ public class CUE4ParseViewModel : ViewModel
         switch (gameDirectory)
         {
             case Constants._FN_LIVE_TRIGGER:
-            {
-                Provider = new StreamedFileProvider("FortniteLive", versionContainer, pathComparer);
-                break;
-            }
-            case Constants._VAL_LIVE_TRIGGER:
-            {
-                Provider = new StreamedFileProvider("ValorantLive", versionContainer, pathComparer);
-                break;
-            }
-            default:
-            {
-                var project = gameDirectory.SubstringBeforeLast(gameDirectory.Contains("eFootball") ? "\\pak" : "\\Content").SubstringAfterLast("\\");
-                Provider = project switch
                 {
-                    "StateOfDecay2" => new DefaultFileProvider(new DirectoryInfo(gameDirectory),
-                    [
-                        new(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\StateOfDecay2\\Saved\\Paks"),
+                    Provider = new StreamedFileProvider("FortniteLive", versionContainer, pathComparer);
+                    break;
+                }
+            case Constants._VAL_LIVE_TRIGGER:
+                {
+                    Provider = new StreamedFileProvider("ValorantLive", versionContainer, pathComparer);
+                    break;
+                }
+            default:
+                {
+                    var project = gameDirectory.SubstringBeforeLast(gameDirectory.Contains("eFootball") ? "\\pak" : "\\Content").SubstringAfterLast("\\");
+                    Provider = project switch
+                    {
+                        "StateOfDecay2" => new DefaultFileProvider(new DirectoryInfo(gameDirectory),
+                        [
+                            new(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\StateOfDecay2\\Saved\\Paks"),
                         new(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\StateOfDecay2\\Saved\\DisabledPaks")
-                    ], SearchOption.AllDirectories, versionContainer, pathComparer),
-                    "eFootball" => new DefaultFileProvider(new DirectoryInfo(gameDirectory),
-                    [
-                        new(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\KONAMI\\eFootball\\ST\\Download")
-                    ], SearchOption.AllDirectories, versionContainer, pathComparer),
-                    _ when versionContainer.Game is EGame.GAME_AshEchoes => new AEDefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, pathComparer),
-                    _ when versionContainer.Game is EGame.GAME_BlackStigma => new DefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, StringComparer.Ordinal),
-                    _ => new DefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, pathComparer)
-                };
+                        ], SearchOption.AllDirectories, versionContainer, pathComparer),
+                        "eFootball" => new DefaultFileProvider(new DirectoryInfo(gameDirectory),
+                        [
+                            new(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\KONAMI\\eFootball\\ST\\Download")
+                        ], SearchOption.AllDirectories, versionContainer, pathComparer),
+                        _ when versionContainer.Game is EGame.GAME_AshEchoes => new AEDefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, pathComparer),
+                        _ when versionContainer.Game is EGame.GAME_BlackStigma => new DefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, StringComparer.Ordinal),
+                        _ => new DefaultFileProvider(gameDirectory, SearchOption.AllDirectories, versionContainer, pathComparer)
+                    };
 
-                break;
-            }
+                    break;
+                }
         }
 
         Provider.ReadScriptData = UserSettings.Default.ReadScriptData;
@@ -239,86 +246,86 @@ public class CUE4ParseViewModel : ViewModel
                     switch (p.LiveGame)
                     {
                         case "FortniteLive":
-                        {
-                            var manifestInfo = _apiEndpointView.EpicApi.GetManifest(cancellationToken);
-                            if (manifestInfo is null)
                             {
-                                throw new FileLoadException("Could not load latest Fortnite manifest, you may have to switch to your local installation.");
+                                var manifestInfo = _apiEndpointView.EpicApi.GetManifest(cancellationToken);
+                                if (manifestInfo is null)
+                                {
+                                    throw new FileLoadException("Could not load latest Fortnite manifest, you may have to switch to your local installation.");
+                                }
+
+                                var cacheDir = Directory.CreateDirectory(Path.Combine(UserSettings.Default.OutputDirectory, ".data")).FullName;
+                                var manifestOptions = new ManifestParseOptions
+                                {
+                                    ChunkCacheDirectory = cacheDir,
+                                    ManifestCacheDirectory = cacheDir,
+                                    ChunkBaseUrl = "http://download.epicgames.com/Builds/Fortnite/CloudDir/",
+                                    Decompressor = ManifestZlibngDotNetDecompressor.Decompress,
+                                    DecompressorState = ZlibHelper.Instance,
+                                    CacheChunksAsIs = false
+                                };
+
+                                var startTs = Stopwatch.GetTimestamp();
+                                FBuildPatchAppManifest manifest;
+
+                                try
+                                {
+                                    (manifest, _) = manifestInfo.DownloadAndParseAsync(manifestOptions,
+                                        cancellationToken: cancellationToken,
+                                        elementManifestPredicate: static x => x.Uri.Host == "download.epicgames.com"
+                                    ).GetAwaiter().GetResult();
+                                }
+                                catch (HttpRequestException ex)
+                                {
+                                    Log.Error("Failed to download manifest ({ManifestUri})", ex.Data["ManifestUri"]?.ToString() ?? "");
+                                    throw;
+                                }
+
+                                if (manifest.TryFindFile("Cloud/IoStoreOnDemand.ini", out var ioStoreOnDemandFile))
+                                {
+                                    IoStoreOnDemand.Read(new StreamReader(ioStoreOnDemandFile.GetStream()));
+                                }
+
+                                Parallel.ForEach(manifest.Files.Where(x => _fnLiveRegex.IsMatch(x.FileName)), fileManifest =>
+                                {
+                                    p.RegisterVfs(fileManifest.FileName, [fileManifest.GetStream()],
+                                        it => new FRandomAccessStreamArchive(it, manifest.FindFile(it)!.GetStream(), p.Versions));
+                                });
+
+                                var elapsedTime = Stopwatch.GetElapsedTime(startTs);
+                                FLogger.Append(ELog.Information, () =>
+                                    FLogger.Text($"Fortnite [LIVE] has been loaded successfully in {elapsedTime.TotalMilliseconds:F1}ms", Constants.WHITE, true));
+                                break;
                             }
-
-                            var cacheDir = Directory.CreateDirectory(Path.Combine(UserSettings.Default.OutputDirectory, ".data")).FullName;
-                            var manifestOptions = new ManifestParseOptions
-                            {
-                                ChunkCacheDirectory = cacheDir,
-                                ManifestCacheDirectory = cacheDir,
-                                ChunkBaseUrl = "http://download.epicgames.com/Builds/Fortnite/CloudDir/",
-                                Decompressor = ManifestZlibngDotNetDecompressor.Decompress,
-                                DecompressorState = ZlibHelper.Instance,
-                                CacheChunksAsIs = false
-                            };
-
-                            var startTs = Stopwatch.GetTimestamp();
-                            FBuildPatchAppManifest manifest;
-
-                            try
-                            {
-                                (manifest, _) = manifestInfo.DownloadAndParseAsync(manifestOptions,
-                                    cancellationToken: cancellationToken,
-                                    elementManifestPredicate: static x => x.Uri.Host == "download.epicgames.com"
-                                ).GetAwaiter().GetResult();
-                            }
-                            catch (HttpRequestException ex)
-                            {
-                                Log.Error("Failed to download manifest ({ManifestUri})", ex.Data["ManifestUri"]?.ToString() ?? "");
-                                throw;
-                            }
-
-                            if (manifest.TryFindFile("Cloud/IoStoreOnDemand.ini", out var ioStoreOnDemandFile))
-                            {
-                                IoStoreOnDemand.Read(new StreamReader(ioStoreOnDemandFile.GetStream()));
-                            }
-
-                            Parallel.ForEach(manifest.Files.Where(x => _fnLiveRegex.IsMatch(x.FileName)), fileManifest =>
-                            {
-                                p.RegisterVfs(fileManifest.FileName, [fileManifest.GetStream()],
-                                    it => new FRandomAccessStreamArchive(it, manifest.FindFile(it)!.GetStream(), p.Versions));
-                            });
-
-                            var elapsedTime = Stopwatch.GetElapsedTime(startTs);
-                            FLogger.Append(ELog.Information, () =>
-                                FLogger.Text($"Fortnite [LIVE] has been loaded successfully in {elapsedTime.TotalMilliseconds:F1}ms", Constants.WHITE, true));
-                            break;
-                        }
                         case "ValorantLive":
-                        {
-                            var manifest = _apiEndpointView.ValorantApi.GetManifest(cancellationToken);
-                            if (manifest == null)
                             {
-                                throw new Exception("Could not load latest Valorant manifest, you may have to switch to your local installation.");
+                                var manifest = _apiEndpointView.ValorantApi.GetManifest(cancellationToken);
+                                if (manifest == null)
+                                {
+                                    throw new Exception("Could not load latest Valorant manifest, you may have to switch to your local installation.");
+                                }
+
+                                Parallel.ForEach(manifest.Paks, pak =>
+                                {
+                                    p.RegisterVfs(pak.GetFullName(), [pak.GetStream(manifest)]);
+                                });
+
+                                FLogger.Append(ELog.Information, () =>
+                                    FLogger.Text($"Valorant '{manifest.Header.GameVersion}' has been loaded successfully", Constants.WHITE, true));
+                                break;
                             }
-
-                            Parallel.ForEach(manifest.Paks, pak =>
-                            {
-                                p.RegisterVfs(pak.GetFullName(), [pak.GetStream(manifest)]);
-                            });
-
-                            FLogger.Append(ELog.Information, () =>
-                                FLogger.Text($"Valorant '{manifest.Header.GameVersion}' has been loaded successfully", Constants.WHITE, true));
-                            break;
-                        }
                     }
 
                     break;
                 case DefaultFileProvider:
-                {
-                    var ioStoreOnDemandPath = Path.Combine(UserSettings.Default.GameDirectory, "..\\..\\..\\Cloud\\IoStoreOnDemand.ini");
-                    if (File.Exists(ioStoreOnDemandPath))
                     {
-                        using var s = new StreamReader(ioStoreOnDemandPath);
-                        IoStoreOnDemand.Read(s);
+                        var ioStoreOnDemandPath = Path.Combine(UserSettings.Default.GameDirectory, "..\\..\\..\\Cloud\\IoStoreOnDemand.ini");
+                        if (File.Exists(ioStoreOnDemandPath))
+                        {
+                            using var s = new StreamReader(ioStoreOnDemandPath);
+                            IoStoreOnDemand.Read(s);
+                        }
+                        break;
                     }
-                    break;
-                }
             }
 
             Provider.Initialize();
@@ -345,7 +352,8 @@ public class CUE4ParseViewModel : ViewModel
 
     public void ClearProvider()
     {
-        if (Provider == null) return;
+        if (Provider == null)
+            return;
 
         AssetsFolder.Folders.Clear();
         SearchVm.SearchResults.Clear();
@@ -364,10 +372,12 @@ public class CUE4ParseViewModel : ViewModel
         await _threadWorkerView.Begin(cancellationToken =>
         {
             // deprecated values
-            if (endpoint.Url == "https://fortnitecentral.genxgames.gg/api/v1/aes") endpoint.Url = "https://uedb.dev/svc/api/v1/fortnite/aes";
+            if (endpoint.Url == "https://fortnitecentral.genxgames.gg/api/v1/aes")
+                endpoint.Url = "https://uedb.dev/svc/api/v1/fortnite/aes";
 
             var aes = _apiEndpointView.DynamicApi.GetAesKeys(cancellationToken, endpoint.Url, endpoint.Path);
-            if (aes is not { IsValid: true }) return;
+            if (aes is not { IsValid: true })
+                return;
 
             UserSettings.Default.CurrentDir.AesKeys = aes;
         });
@@ -378,7 +388,8 @@ public class CUE4ParseViewModel : ViewModel
         await _threadWorkerView.Begin(cancellationToken =>
         {
             var info = _apiEndpointView.FModelApi.GetNews(cancellationToken, Provider.ProjectName);
-            if (info == null) return;
+            if (info == null)
+                return;
 
             FLogger.Append(ELog.None, () =>
             {
@@ -408,7 +419,8 @@ public class CUE4ParseViewModel : ViewModel
             else if (endpoint.IsValid)
             {
                 // deprecated values
-                if (endpoint.Path == "$.[?(@.meta.compressionMethod=='Oodle')].['url','fileName']") endpoint.Path = "$.[0].['url','fileName']";
+                if (endpoint.Path == "$.[?(@.meta.compressionMethod=='Oodle')].['url','fileName']")
+                    endpoint.Path = "$.[0].['url','fileName']";
                 if (endpoint.Url == "https://fortnitecentral.genxgames.gg/api/v1/mappings")
                 {
                     endpoint.Url = "https://uedb.dev/svc/api/v1/fortnite/mappings";
@@ -421,7 +433,8 @@ public class CUE4ParseViewModel : ViewModel
                 {
                     foreach (var mapping in mappings)
                     {
-                        if (!mapping.IsValid) continue;
+                        if (!mapping.IsValid)
+                            continue;
 
                         var mappingPath = Path.Combine(mappingsFolder, mapping.FileName);
                         if (force || !File.Exists(mappingPath) || new FileInfo(mappingPath).Length == 0)
@@ -437,7 +450,8 @@ public class CUE4ParseViewModel : ViewModel
                 if (Provider.MappingsContainer == null)
                 {
                     var latestUsmaps = new DirectoryInfo(mappingsFolder).GetFiles("*_oo.usmap");
-                    if (latestUsmaps.Length <= 0) return;
+                    if (latestUsmaps.Length <= 0)
+                        return;
 
                     var latestUsmapInfo = latestUsmaps.OrderBy(f => f.LastWriteTime).Last();
                     Provider.MappingsContainer = new FileUsmapTypeMappingsProvider(latestUsmapInfo.FullName);
@@ -486,10 +500,12 @@ public class CUE4ParseViewModel : ViewModel
         {
             var inst = new List<InstructionToken>();
             IoStoreOnDemand.FindPropertyInstructions("Endpoint", "TocPath", inst);
-            if (inst.Count <= 0) return;
+            if (inst.Count <= 0)
+                return;
 
             var ioStoreOnDemandPath = Path.Combine(UserSettings.Default.GameDirectory, "..\\..\\..\\Cloud", inst[0].Value.SubstringAfterLast("/").SubstringBefore("\""));
-            if (!File.Exists(ioStoreOnDemandPath)) return;
+            if (!File.Exists(ioStoreOnDemandPath))
+                return;
 
             await Provider.RegisterVfsAsync(new IoChunkToc(ioStoreOnDemandPath));
             var onDemandCount = await Provider.MountAsync();
@@ -518,7 +534,8 @@ public class CUE4ParseViewModel : ViewModel
 
     private Task LoadGameLocalizedResources()
     {
-        if (LocalResourcesDone) return Task.CompletedTask;
+        if (LocalResourcesDone)
+            return Task.CompletedTask;
         return Task.Run(() =>
         {
             LocalResourcesDone = Provider.TryChangeCulture(Provider.GetLanguageCode(UserSettings.Default.AssetLanguage));
@@ -527,11 +544,13 @@ public class CUE4ParseViewModel : ViewModel
 
     private Task LoadHotfixedLocalizedResources()
     {
-        if (!Provider.ProjectName.Equals("fortnitegame", StringComparison.OrdinalIgnoreCase) || HotfixedResourcesDone) return Task.CompletedTask;
+        if (!Provider.ProjectName.Equals("fortnitegame", StringComparison.OrdinalIgnoreCase) || HotfixedResourcesDone)
+            return Task.CompletedTask;
         return Task.Run(() =>
         {
             var hotfixes = ApplicationService.ApiEndpointView.DillyApi.GetHotfixes(CancellationToken.None, Provider.GetLanguageCode(UserSettings.Default.AssetLanguage));
-            if (hotfixes == null) return;
+            if (hotfixes == null)
+                return;
 
             Provider.Internationalization.Override(hotfixes);
             HotfixedResourcesDone = true;
@@ -541,7 +560,8 @@ public class CUE4ParseViewModel : ViewModel
     private int _virtualPathCount { get; set; }
     public Task LoadVirtualPaths()
     {
-        if (_virtualPathCount > 0) return Task.CompletedTask;
+        if (_virtualPathCount > 0)
+            return Task.CompletedTask;
         return Task.Run(() =>
         {
             _virtualPathCount = Provider.LoadVirtualPaths(UserSettings.Default.CurrentDir.UeVersion.GetVersion());
@@ -584,7 +604,8 @@ public class CUE4ParseViewModel : ViewModel
             }
         }
 
-        foreach (var f in folder.Folders) BulkFolder(cancellationToken, f, action);
+        foreach (var f in folder.Folders)
+            BulkFolder(cancellationToken, f, action);
     }
 
     public void ExportFolder(CancellationToken cancellationToken, TreeItem folder)
@@ -595,7 +616,8 @@ public class CUE4ParseViewModel : ViewModel
             ExportData(entry.Asset, false);
         });
 
-        foreach (var f in folder.Folders) ExportFolder(cancellationToken, f);
+        foreach (var f in folder.Folders)
+            ExportFolder(cancellationToken, f);
     }
 
     public void ExtractFolder(CancellationToken cancellationToken, TreeItem folder)
@@ -621,8 +643,10 @@ public class CUE4ParseViewModel : ViewModel
         ApplicationService.ApplicationView.IsAssetsExplorerVisible = false;
         Log.Information("User DOUBLE-CLICKED to extract '{FullPath}'", entry.Path);
 
-        if (addNewTab && TabControl.CanAddTabs) TabControl.AddTab(entry);
-        else TabControl.SelectedTab.SoftReset(entry);
+        if (addNewTab && TabControl.CanAddTabs)
+            TabControl.AddTab(entry);
+        else
+            TabControl.SelectedTab.SoftReset(entry);
         TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector(entry.Extension);
 
         var updateUi = !HasFlag(bulk, EBulkType.Auto);
@@ -633,44 +657,45 @@ public class CUE4ParseViewModel : ViewModel
         {
             case "uasset":
             case "umap":
-            {
-                var result = Provider.GetLoadPackageResult(entry);
-                TabControl.SelectedTab.TitleExtra = result.TabTitleExtra;
-
-                if (saveProperties || updateUi)
                 {
-                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(result.GetDisplayData(saveProperties), Formatting.Indented), saveProperties, updateUi);
-                    if (saveProperties) break; // do not search for viewable exports if we are dealing with jsons
-                }
+                    var result = Provider.GetLoadPackageResult(entry);
+                    TabControl.SelectedTab.TitleExtra = result.TabTitleExtra;
 
-                for (var i = result.InclusiveStart; i < result.ExclusiveEnd; i++)
-                {
-                    if (CheckExport(cancellationToken, result.Package, i, bulk))
-                        break;
-                }
+                    if (saveProperties || updateUi)
+                    {
+                        TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(result.GetDisplayData(saveProperties), Formatting.Indented), saveProperties, updateUi);
+                        if (saveProperties)
+                            break; // do not search for viewable exports if we are dealing with jsons
+                    }
 
-                break;
-            }
+                    for (var i = result.InclusiveStart; i < result.ExclusiveEnd; i++)
+                    {
+                        if (CheckExport(cancellationToken, result.Package, i, bulk))
+                            break;
+                    }
+
+                    break;
+                }
             case "ini" when entry.Name.Contains("BinaryConfig"):
-            {
-                var ar = entry.CreateReader();
-                var configCache = new FConfigCacheIni(ar);
+                {
+                    var ar = entry.CreateReader();
+                    var configCache = new FConfigCacheIni(ar);
 
-                TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("json");
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(configCache, Formatting.Indented), saveProperties, updateUi);
+                    TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("json");
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(configCache, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "dat" when Provider.Versions.Game is EGame.GAME_Aion2:
-            {
-                ProcessAion2DatFile(entry, updateUi, saveProperties);
-                break;
-            }
+                {
+                    ProcessAion2DatFile(entry, updateUi, saveProperties);
+                    break;
+                }
             case "dbc" when Provider.Versions.Game is EGame.GAME_AshesOfCreation:
-            {
-                ProcessCacheDBFile(entry, updateUi, saveProperties);
-                break;
-            }
+                {
+                    ProcessCacheDBFile(entry, updateUi, saveProperties);
+                    break;
+                }
             case "upluginmanifest":
             case "code-workspace":
             case "projectstore":
@@ -737,114 +762,114 @@ public class CUE4ParseViewModel : ViewModel
             case "bl":
             case "bm":
             case "br":
-            {
-                var data = Provider.SaveAsset(entry);
-                using var stream = new MemoryStream(data) { Position = 0 };
-                using var reader = new StreamReader(stream);
-
-                TabControl.SelectedTab.SetDocumentText(reader.ReadToEnd(), saveProperties, updateUi);
-
-                break;
-            }
-            case "locmeta":
-            {
-                var archive = entry.CreateReader();
-                var metadata = new FTextLocalizationMetaDataResource(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(metadata, Formatting.Indented), saveProperties, updateUi);
-
-                break;
-            }
-            case "locres":
-            {
-                var archive = entry.CreateReader();
-                var locres = new FTextLocalizationResource(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(locres, Formatting.Indented), saveProperties, updateUi);
-
-                break;
-            }
-            case "bin" when entry.Name.Contains("AssetRegistry", StringComparison.OrdinalIgnoreCase):
-            {
-                var archive = entry.CreateReader();
-                var registry = new FAssetRegistryState(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(registry, Formatting.Indented), saveProperties, updateUi);
-
-                break;
-            }
-            case "bin" when entry.Name.Contains("GlobalShaderCache", StringComparison.OrdinalIgnoreCase):
-            {
-                var archive = entry.CreateReader();
-                var registry = new FGlobalShaderCache(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(registry, Formatting.Indented), saveProperties, updateUi);
-
-                break;
-            }
-            case "bank":
-            {
-                var archive = entry.CreateReader();
-                if (!FmodProvider.TryLoadBank(archive, entry.NameWithoutExtension, out var fmodReader))
                 {
-                    Log.Error($"Failed to load FMOD bank {entry.Path}");
+                    var data = Provider.SaveAsset(entry);
+                    using var stream = new MemoryStream(data) { Position = 0 };
+                    using var reader = new StreamReader(stream);
+
+                    TabControl.SelectedTab.SetDocumentText(reader.ReadToEnd(), saveProperties, updateUi);
+
                     break;
                 }
-
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(fmodReader, Formatting.Indented, converters: [new FmodSoundBankConverter(), new StringEnumConverter()]), saveProperties, updateUi);
-
-                var extractedSounds = FmodProvider.ExtractBankSounds(fmodReader);
-                var directory = Path.GetDirectoryName(entry.Path) ?? "/FMOD/Desktop/";
-                foreach (var sound in extractedSounds)
+            case "locmeta":
                 {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
-                }
+                    var archive = entry.CreateReader();
+                    var metadata = new FTextLocalizationMetaDataResource(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(metadata, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
+            case "locres":
+                {
+                    var archive = entry.CreateReader();
+                    var locres = new FTextLocalizationResource(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(locres, Formatting.Indented), saveProperties, updateUi);
+
+                    break;
+                }
+            case "bin" when entry.Name.Contains("AssetRegistry", StringComparison.OrdinalIgnoreCase):
+                {
+                    var archive = entry.CreateReader();
+                    var registry = new FAssetRegistryState(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(registry, Formatting.Indented), saveProperties, updateUi);
+
+                    break;
+                }
+            case "bin" when entry.Name.Contains("GlobalShaderCache", StringComparison.OrdinalIgnoreCase):
+                {
+                    var archive = entry.CreateReader();
+                    var registry = new FGlobalShaderCache(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(registry, Formatting.Indented), saveProperties, updateUi);
+
+                    break;
+                }
+            case "bank":
+                {
+                    var archive = entry.CreateReader();
+                    if (!FmodProvider.TryLoadBank(archive, entry.NameWithoutExtension, out var fmodReader))
+                    {
+                        Log.Error($"Failed to load FMOD bank {entry.Path}");
+                        break;
+                    }
+
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(fmodReader, Formatting.Indented, converters: [new FmodSoundBankConverter(), new StringEnumConverter()]), saveProperties, updateUi);
+
+                    var extractedSounds = FmodProvider.ExtractBankSounds(fmodReader);
+                    var directory = Path.GetDirectoryName(entry.Path) ?? "/FMOD/Desktop/";
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+
+                    break;
+                }
             case "bnk":
             case "pck":
-            {
-                var archive = entry.CreateReader();
-                var wwise = new WwiseReader(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(wwise, Formatting.Indented), saveProperties, updateUi);
-
-                var medias = WwiseProvider.ExtractBankSounds(wwise);
-                foreach (var media in medias)
                 {
-                    SaveAndPlaySound(cancellationToken, media.OutputPath, media.Extension, media.Data, saveAudio, updateUi);
-                }
+                    var archive = entry.CreateReader();
+                    var wwise = new WwiseReader(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(wwise, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    var medias = WwiseProvider.ExtractBankSounds(wwise);
+                    foreach (var media in medias)
+                    {
+                        SaveAndPlaySound(cancellationToken, media.OutputPath, media.Extension, media.Data, saveAudio, updateUi);
+                    }
+
+                    break;
+                }
             case "awb":
-            {
-                var archive = entry.CreateReader();
-                var awbReader = new AwbReader(archive);
-
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(awbReader, Formatting.Indented), saveProperties, updateUi);
-
-                var directory = Path.GetDirectoryName(archive.Name) ?? "/Criware/";
-                var extractedSounds = CriWareProvider.ExtractCriWareSounds(awbReader, archive.Name);
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
-                }
+                    var archive = entry.CreateReader();
+                    var awbReader = new AwbReader(archive);
 
-                break;
-            }
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(awbReader, Formatting.Indented), saveProperties, updateUi);
+
+                    var directory = Path.GetDirectoryName(archive.Name) ?? "/Criware/";
+                    var extractedSounds = CriWareProvider.ExtractCriWareSounds(awbReader, archive.Name);
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+
+                    break;
+                }
             case "acb":
-            {
-                var archive = entry.CreateReader();
-                var acbReader = new AcbReader(archive);
-
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(acbReader, Formatting.Indented), saveProperties, updateUi);
-
-                var directory = Path.GetDirectoryName(archive.Name) ?? "/Criware/";
-                var extractedSounds = CriWareProvider.ExtractCriWareSounds(acbReader, archive.Name);
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
-                }
+                    var archive = entry.CreateReader();
+                    var acbReader = new AcbReader(archive);
 
-                break;
-            }
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(acbReader, Formatting.Indented), saveProperties, updateUi);
+
+                    var directory = Path.GetDirectoryName(archive.Name) ?? "/Criware/";
+                    var extractedSounds = CriWareProvider.ExtractCriWareSounds(acbReader, archive.Name);
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+
+                    break;
+                }
             case "xvag":
             case "flac":
             case "at9":
@@ -853,55 +878,55 @@ public class CUE4ParseViewModel : ViewModel
             case "WAV":
             case "ogg":
                 // todo: CSCore.MediaFoundation.MediaFoundationException The byte stream type of the given URL is unsupported. case "aif":
-            {
-                var data = Provider.SaveAsset(entry);
-                SaveAndPlaySound(cancellationToken, entry.PathWithoutExtension, entry.Extension, data, saveAudio, updateUi);
+                {
+                    var data = Provider.SaveAsset(entry);
+                    SaveAndPlaySound(cancellationToken, entry.PathWithoutExtension, entry.Extension, data, saveAudio, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "udic":
-            {
-                var archive = entry.CreateReader();
-                var header = new FOodleDictionaryArchive(archive).Header;
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(header, Formatting.Indented), saveProperties, updateUi);
+                {
+                    var archive = entry.CreateReader();
+                    var header = new FOodleDictionaryArchive(archive).Header;
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(header, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "png":
             case "jpg":
             case "bmp":
-            {
-                var data = Provider.SaveAsset(entry);
-                using var stream = new MemoryStream(data) { Position = 0 };
-                TabControl.SelectedTab.AddImage(entry.NameWithoutExtension, false, SKBitmap.Decode(stream), saveTextures, updateUi);
+                {
+                    var data = Provider.SaveAsset(entry);
+                    using var stream = new MemoryStream(data) { Position = 0 };
+                    TabControl.SelectedTab.AddImage(entry.NameWithoutExtension, false, SKBitmap.Decode(stream), saveTextures, updateUi);
 
-                break;
-            }
-            case "svg":
-            {
-                var data = Provider.SaveAsset(entry);
-                using var stream = new MemoryStream(data) { Position = 0 };
-                var svg = new SKSvg();
-                svg.Load(stream);
-
-                int size = 512;
-                var bitmap = new SKBitmap(size, size);
-                using var canvas = new SKCanvas(bitmap);
-                canvas.Clear(SKColors.Transparent);
-
-                if (svg.Picture == null)
                     break;
+                }
+            case "svg":
+                {
+                    var data = Provider.SaveAsset(entry);
+                    using var stream = new MemoryStream(data) { Position = 0 };
+                    var svg = new SKSvg();
+                    svg.Load(stream);
 
-                var bounds = svg.Picture.CullRect;
-                float scale = Math.Min(size / bounds.Width, size / bounds.Height);
-                canvas.Scale(scale);
-                canvas.Translate(-bounds.Left, -bounds.Top);
-                canvas.DrawPicture(svg.Picture);
+                    int size = 512;
+                    var bitmap = new SKBitmap(size, size);
+                    using var canvas = new SKCanvas(bitmap);
+                    canvas.Clear(SKColors.Transparent);
 
-                TabControl.SelectedTab.AddImage(entry.NameWithoutExtension, false, bitmap, saveTextures, updateUi);
+                    if (svg.Picture == null)
+                        break;
 
-                break;
-            }
+                    var bounds = svg.Picture.CullRect;
+                    float scale = Math.Min(size / bounds.Width, size / bounds.Height);
+                    canvas.Scale(scale);
+                    canvas.Translate(-bounds.Left, -bounds.Top);
+                    canvas.DrawPicture(svg.Picture);
+
+                    TabControl.SelectedTab.AddImage(entry.NameWithoutExtension, false, bitmap, saveTextures, updateUi);
+
+                    break;
+                }
             case "ufont":
             case "otf":
             case "ttf":
@@ -910,44 +935,44 @@ public class CUE4ParseViewModel : ViewModel
                 break;
             case "ushaderbytecode":
             case "ushadercode":
-            {
-                var archive = entry.CreateReader();
-                var ar = new FShaderCodeArchive(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
+                {
+                    var archive = entry.CreateReader();
+                    var ar = new FShaderCodeArchive(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "upipelinecache":
-            {
-                var archive = entry.CreateReader();
-                var ar = new FPipelineCacheFile(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
+                {
+                    var archive = entry.CreateReader();
+                    var ar = new FPipelineCacheFile(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "stinfo":
-            {
-                var archive = entry.CreateReader();
-                var ar = new FShaderTypeHashes(archive);
-                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
+                {
+                    var archive = entry.CreateReader();
+                    var ar = new FShaderTypeHashes(archive);
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(ar, Formatting.Indented), saveProperties, updateUi);
 
-                break;
-            }
+                    break;
+                }
             case "res": // just skip
             case "luac": // compiled lua
             case "bytes": // wuthering waves
                 break;
             default:
-            {
-                Log.Warning($"The package '{entry.Name}' is of an unknown type.");
-                if (!UnknownExtensions.Contains(entry.Extension))
                 {
-                    UnknownExtensions.Add(entry.Extension);
-                FLogger.Append(ELog.Warning, () =>
-                        FLogger.Text($"There are some packages with an unknown type {entry.Extension}. Check Log file for a full list.", Constants.WHITE, true));
+                    Log.Warning($"The package '{entry.Name}' is of an unknown type.");
+                    if (!UnknownExtensions.Contains(entry.Extension))
+                    {
+                        UnknownExtensions.Add(entry.Extension);
+                        FLogger.Append(ELog.Warning, () =>
+                                FLogger.Text($"There are some packages with an unknown type {entry.Extension}. Check Log file for a full list.", Constants.WHITE, true));
+                    }
+                    break;
                 }
-                break;
-            }
         }
 
         void ProcessAion2DatFile(GameFile entry, bool updateUi, bool saveProperties)
@@ -1035,236 +1060,239 @@ public class CUE4ParseViewModel : ViewModel
         var saveAudio = HasFlag(bulk, EBulkType.Audio);
 
         var pointer = new FPackageIndex(pkg, index + 1).ResolvedObject;
-        if (pointer?.Object is null) return false;
+        if (pointer?.Object is null)
+            return false;
 
         var dummy = ((AbstractUePackage) pkg).ConstructObject(pointer.Class, pkg);
         switch (dummy)
         {
             case UVerseDigest when isNone && pointer.Object.Value is UVerseDigest verseDigest:
-            {
-                if (!TabControl.CanAddTabs) return false;
-
-                TabControl.AddTab($"{verseDigest.ProjectName}.verse");
-                TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("verse");
-                TabControl.SelectedTab.SetDocumentText(verseDigest.ReadableCode, false, false);
-                return true;
-            }
-            case UTexture when (isNone || saveTextures) && pointer.Object.Value is UTexture texture:
-            {
-                TabControl.SelectedTab.AddImage(texture, saveTextures, updateUi);
-                return false;
-            }
-            case USvgAsset when (isNone || saveTextures) && pointer.Object.Value is USvgAsset svgasset:
-            {
-                const int size = 512;
-                var data = svgasset.GetOrDefault<byte[]>("SvgData");
-                var sourceFile = svgasset.GetOrDefault<string>("SourceFile");
-                using var stream = new MemoryStream(data) { Position = 0 };
-
-                var svg = new SKSvg();
-                svg.Load(stream);
-
-                if (svg.Picture == null)
-                    return false;
-
-                var b = svg.Picture.CullRect;
-                float s = Math.Min(size / b.Width, size / b.Height);
-
-                var bitmap = new SKBitmap(size, size);
-                using var canvas = new SKCanvas(bitmap);
-                using var paint = new SKPaint { IsAntialias = true, FilterQuality = SKFilterQuality.Medium };
-
-                canvas.Scale(s);
-                canvas.Translate(-b.Left, -b.Top);
-                canvas.DrawPicture(svg.Picture, paint);
-
-                if (saveTextures)
                 {
-                    var fileName = sourceFile.SubstringAfterLast('/');
-                    var path = Path.Combine(UserSettings.Default.TextureDirectory,
-                        UserSettings.Default.KeepDirectoryStructure ? TabControl.SelectedTab.Entry.Directory : "", fileName!).Replace('\\', '/');
+                    if (!TabControl.CanAddTabs)
+                        return false;
 
-                    Directory.CreateDirectory(path.SubstringBeforeLast('/'));
+                    TabControl.AddTab($"{verseDigest.ProjectName}.verse");
+                    TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("verse");
+                    TabControl.SelectedTab.SetDocumentText(verseDigest.ReadableCode, false, false);
+                    return true;
+                }
+            case UTexture when (isNone || saveTextures) && pointer.Object.Value is UTexture texture:
+                {
+                    TabControl.SelectedTab.AddImage(texture, saveTextures, updateUi);
+                    return false;
+                }
+            case USvgAsset when (isNone || saveTextures) && pointer.Object.Value is USvgAsset svgasset:
+                {
+                    const int size = 512;
+                    var data = svgasset.GetOrDefault<byte[]>("SvgData");
+                    var sourceFile = svgasset.GetOrDefault<string>("SourceFile");
+                    using var stream = new MemoryStream(data) { Position = 0 };
 
-                    using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
-                    fs.Write(data, 0, data.Length);
-                    if (File.Exists(path))
+                    var svg = new SKSvg();
+                    svg.Load(stream);
+
+                    if (svg.Picture == null)
+                        return false;
+
+                    var b = svg.Picture.CullRect;
+                    float s = Math.Min(size / b.Width, size / b.Height);
+
+                    var bitmap = new SKBitmap(size, size);
+                    using var canvas = new SKCanvas(bitmap);
+                    using var paint = new SKPaint { IsAntialias = true, FilterQuality = SKFilterQuality.Medium };
+
+                    canvas.Scale(s);
+                    canvas.Translate(-b.Left, -b.Top);
+                    canvas.DrawPicture(svg.Picture, paint);
+
+                    if (saveTextures)
                     {
-                        Log.Information("{FileName} successfully saved", fileName);
-                        if (updateUi)
+                        var fileName = sourceFile.SubstringAfterLast('/');
+                        var path = Path.Combine(UserSettings.Default.TextureDirectory,
+                            UserSettings.Default.KeepDirectoryStructure ? TabControl.SelectedTab.Entry.Directory : "", fileName!).Replace('\\', '/');
+
+                        Directory.CreateDirectory(path.SubstringBeforeLast('/'));
+
+                        using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+                        fs.Write(data, 0, data.Length);
+                        if (File.Exists(path))
                         {
-                            FLogger.Append(ELog.Information, () =>
+                            Log.Information("{FileName} successfully saved", fileName);
+                            if (updateUi)
                             {
-                                FLogger.Text("Successfully saved ", Constants.WHITE);
-                                FLogger.Link(fileName, path, true);
-                            });
+                                FLogger.Append(ELog.Information, () =>
+                                {
+                                    FLogger.Text("Successfully saved ", Constants.WHITE);
+                                    FLogger.Link(fileName, path, true);
+                                });
+                            }
+                        }
+                        else
+                        {
+                            Log.Error("{FileName} could not be saved", fileName);
+                            if (updateUi)
+                                FLogger.Append(ELog.Error, () => FLogger.Text($"Could not save '{fileName}'", Constants.WHITE, true));
                         }
                     }
-                    else
-                    {
-                        Log.Error("{FileName} could not be saved", fileName);
-                        if (updateUi)
-                            FLogger.Append(ELog.Error, () => FLogger.Text($"Could not save '{fileName}'", Constants.WHITE, true));
-                    }
-                }
 
-                TabControl.SelectedTab.AddImage(sourceFile.SubstringAfterLast('/'), false, bitmap, false, updateUi);
-                return false;
-            }
+                    TabControl.SelectedTab.AddImage(sourceFile.SubstringAfterLast('/'), false, bitmap, false, updateUi);
+                    return false;
+                }
             // Supermassive Games (for example - The Dark Pictures Anthology: House of Ashes etc.)
             case UExternalSource when (isNone || saveAudio) && pointer.Object.Value is UExternalSource externalSource:
-            {
-                var audioName = Path.GetFileNameWithoutExtension(externalSource.ExternalSourcePath);
-                SaveAndPlaySound(cancellationToken, audioName, "wem", externalSource.Data?.WemFile ?? [], saveAudio, updateUi);
-                return false;
-            }
+                {
+                    var audioName = Path.GetFileNameWithoutExtension(externalSource.ExternalSourcePath);
+                    SaveAndPlaySound(cancellationToken, audioName, "wem", externalSource.Data?.WemFile ?? [], saveAudio, updateUi);
+                    return false;
+                }
             case UAkAudioBank when (isNone || saveAudio) && pointer.Object.Value is UAkAudioBank soundBank:
-            {
-                var extractedSounds = WwiseProvider.ExtractBankSounds(soundBank);
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    var extractedSounds = WwiseProvider.ExtractBankSounds(soundBank);
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             case UAkAudioEvent when (isNone || saveAudio) && pointer.Object.Value is UAkAudioEvent audioEvent:
-            {
-                var extractedSounds = WwiseProvider.ExtractAudioEventSounds(audioEvent);
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    var extractedSounds = WwiseProvider.ExtractAudioEventSounds(audioEvent);
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             case UFMODEvent when (isNone || saveAudio) && pointer.Object.Value is UFMODEvent fmodEvent:
-            {
-                var extractedSounds = FmodProvider.ExtractEventSounds(fmodEvent);
-                var directory = Path.GetDirectoryName(fmodEvent.Owner?.Name) ?? "/FMOD/Desktop/";
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    var extractedSounds = FmodProvider.ExtractEventSounds(fmodEvent);
+                    var directory = Path.GetDirectoryName(fmodEvent.Owner?.Name) ?? "/FMOD/Desktop/";
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             case UFMODBank when (isNone || saveAudio) && pointer.Object.Value is UFMODBank fmodBank:
-            {
-                var extractedSounds = FmodProvider.ExtractBankSounds(fmodBank);
-                var directory = Path.GetDirectoryName(fmodBank.Owner?.Name) ?? "/FMOD/Desktop/";
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    var extractedSounds = FmodProvider.ExtractBankSounds(fmodBank);
+                    var directory = Path.GetDirectoryName(fmodBank.Owner?.Name) ?? "/FMOD/Desktop/";
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             case USoundAtomCueSheet or UAtomCueSheet or USoundAtomCue or UAtomWaveBank when (isNone || saveAudio) && pointer.Object.Value is UObject atomObject:
-            {
-                var extractedSounds = atomObject switch
                 {
-                    USoundAtomCueSheet cueSheet => CriWareProvider.ExtractCriWareSounds(cueSheet),
-                    UAtomCueSheet cueSheet => CriWareProvider.ExtractCriWareSounds(cueSheet),
-                    USoundAtomCue cue => CriWareProvider.ExtractCriWareSounds(cue),
-                    UAtomWaveBank awb => CriWareProvider.ExtractCriWareSounds(awb),
-                    _ => []
-                };
+                    var extractedSounds = atomObject switch
+                    {
+                        USoundAtomCueSheet cueSheet => CriWareProvider.ExtractCriWareSounds(cueSheet),
+                        UAtomCueSheet cueSheet => CriWareProvider.ExtractCriWareSounds(cueSheet),
+                        USoundAtomCue cue => CriWareProvider.ExtractCriWareSounds(cue),
+                        UAtomWaveBank awb => CriWareProvider.ExtractCriWareSounds(awb),
+                        _ => []
+                    };
 
-                var directory = Path.GetDirectoryName(atomObject.Owner?.Name) ?? "/Criware/";
-                directory = Path.GetDirectoryName(atomObject.Owner.Provider.FixPath(directory));
-                foreach (var sound in extractedSounds)
-                {
-                    SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name).Replace("\\", "/"), sound.Extension, sound.Data, saveAudio, updateUi);
+                    var directory = Path.GetDirectoryName(atomObject.Owner?.Name) ?? "/Criware/";
+                    directory = Path.GetDirectoryName(atomObject.Owner.Provider.FixPath(directory));
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, Path.Combine(directory, sound.Name).Replace("\\", "/"), sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             case UAkMediaAssetData when isNone || saveAudio:
             case USoundWave when isNone || saveAudio:
-            {
-                // If UAkMediaAsset exists in the same package it should be used to handle the audio instead (because it contains actual audio name)
-                if (pointer.Object.Value is UAkMediaAssetData dataObj && dataObj.Outer is UAkMediaAsset)
-                    return false;
-
-                var shouldDecompress = UserSettings.Default.CompressedAudioMode == ECompressedAudio.PlayDecompressed;
-                pointer.Object.Value.Decode(shouldDecompress, out var audioFormat, out var data);
-                var hasAf = !string.IsNullOrEmpty(audioFormat);
-                if (data == null || !hasAf)
                 {
-                    if (hasAf) FLogger.Append(ELog.Warning, () => FLogger.Text($"Unsupported audio format '{audioFormat}'", Constants.WHITE, true));
+                    // If UAkMediaAsset exists in the same package it should be used to handle the audio instead (because it contains actual audio name)
+                    if (pointer.Object.Value is UAkMediaAssetData dataObj && dataObj.Outer is UAkMediaAsset)
+                        return false;
+
+                    var shouldDecompress = UserSettings.Default.CompressedAudioMode == ECompressedAudio.PlayDecompressed;
+                    pointer.Object.Value.Decode(shouldDecompress, out var audioFormat, out var data);
+                    var hasAf = !string.IsNullOrEmpty(audioFormat);
+                    if (data == null || !hasAf)
+                    {
+                        if (hasAf)
+                            FLogger.Append(ELog.Warning, () => FLogger.Text($"Unsupported audio format '{audioFormat}'", Constants.WHITE, true));
+                        return false;
+                    }
+
+                    SaveAndPlaySound(cancellationToken, TabControl.SelectedTab.Entry.PathWithoutExtension.Replace('\\', '/'), audioFormat, data, saveAudio, updateUi);
                     return false;
                 }
-
-                SaveAndPlaySound(cancellationToken, TabControl.SelectedTab.Entry.PathWithoutExtension.Replace('\\', '/'), audioFormat, data, saveAudio, updateUi);
-                return false;
-            }
             case UAkMediaAsset when (isNone || saveAudio) && pointer.Object.Value is UAkMediaAsset akMediaAsset:
-            {
-                var audioName = akMediaAsset.MediaName;
-                if (akMediaAsset.CurrentMediaAssetData?.TryLoad<UAkMediaAssetData>(out var akMediaAssetData) is true)
+                {
+                    var audioName = akMediaAsset.MediaName;
+                    if (akMediaAsset.CurrentMediaAssetData?.TryLoad<UAkMediaAssetData>(out var akMediaAssetData) is true)
+                    {
+                        var shouldDecompress = UserSettings.Default.CompressedAudioMode is ECompressedAudio.PlayDecompressed;
+                        akMediaAssetData.Decode(shouldDecompress, out var audioFormat, out var data);
+
+                        SaveAndPlaySound(cancellationToken, audioName, audioFormat, data, saveAudio, updateUi);
+                    }
+                    return false;
+                }
+            case UAkAudioEventData when (isNone || saveAudio) && pointer.Object.Value is UAkAudioEventData akAudioEventData:
                 {
                     var shouldDecompress = UserSettings.Default.CompressedAudioMode is ECompressedAudio.PlayDecompressed;
-                    akMediaAssetData.Decode(shouldDecompress, out var audioFormat, out var data);
-
-                    SaveAndPlaySound(cancellationToken, audioName, audioFormat, data, saveAudio, updateUi);
-                }
-                return false;
-            }
-            case UAkAudioEventData when (isNone || saveAudio) && pointer.Object.Value is UAkAudioEventData akAudioEventData:
-            {
-                var shouldDecompress = UserSettings.Default.CompressedAudioMode is ECompressedAudio.PlayDecompressed;
-                foreach (var mediaIndex in akAudioEventData.MediaList)
-                {
-                    if (mediaIndex.TryLoad<UAkMediaAsset>(out var akMediaAsset))
+                    foreach (var mediaIndex in akAudioEventData.MediaList)
                     {
-                        if (akMediaAsset.CurrentMediaAssetData?.TryLoad<UAkMediaAssetData>(out var akMediaAssetData) is true)
+                        if (mediaIndex.TryLoad<UAkMediaAsset>(out var akMediaAsset))
                         {
-                            var audioName = akMediaAsset.MediaName ?? $"{akAudioEventData.Outer.Name} ({akMediaAsset.ID})";
-                            akMediaAssetData.Decode(shouldDecompress, out var audioFormat, out var data);
+                            if (akMediaAsset.CurrentMediaAssetData?.TryLoad<UAkMediaAssetData>(out var akMediaAssetData) is true)
+                            {
+                                var audioName = akMediaAsset.MediaName ?? $"{akAudioEventData.Outer.Name} ({akMediaAsset.ID})";
+                                akMediaAssetData.Decode(shouldDecompress, out var audioFormat, out var data);
 
-                            SaveAndPlaySound(cancellationToken, audioName, audioFormat, data, saveAudio, updateUi);
+                                SaveAndPlaySound(cancellationToken, audioName, audioFormat, data, saveAudio, updateUi);
+                            }
                         }
                     }
+                    return false;
                 }
-                return false;
-            }
             // Borderlands 3
             case UDialogPerformanceData when (isNone || saveAudio) && pointer.Object.Value is UDialogPerformanceData dialogPerformanceData:
-            {
-                var extractedSounds = WwiseProvider.ExtractDialogBorderlands3(dialogPerformanceData);
-                foreach (var sound in extractedSounds)
                 {
-                    SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    var extractedSounds = WwiseProvider.ExtractDialogBorderlands3(dialogPerformanceData);
+                    foreach (var sound in extractedSounds)
+                    {
+                        SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                    }
+                    return false;
                 }
-                return false;
-            }
             // Borderlands 4
             case UFaceFXAnimSet when (isNone || saveAudio) && pointer.Object.Value is UFaceFXAnimSet faceFXAnimSet:
-            {
-                if (Provider.Versions.Game is not EGame.GAME_Borderlands4)
-                    return false;
-
-                foreach (var faceFXAnimData in faceFXAnimSet.FaceFXAnimDataList)
                 {
-                    var extractedSounds = WwiseProvider.ExtractAudioEventBorderlands4(faceFXAnimData.ID.Name, false);
-                    foreach (var sound in extractedSounds)
-                    {
-                        SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
-                    }
-                }
+                    if (Provider.Versions.Game is not EGame.GAME_Borderlands4)
+                        return false;
 
-                return false;
-            }
+                    foreach (var faceFXAnimData in faceFXAnimSet.FaceFXAnimDataList)
+                    {
+                        var extractedSounds = WwiseProvider.ExtractAudioEventBorderlands4(faceFXAnimData.ID.Name, false);
+                        foreach (var sound in extractedSounds)
+                        {
+                            SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                        }
+                    }
+
+                    return false;
+                }
             // Borderlands 4
             case UGbxGraphAsset when (isNone || saveAudio) && pointer.Object.Value is UGbxGraphAsset gbxGraphAsset:
-            {
-                foreach (var (eventName, useSoundTag) in GbxAudioUtil.GetAndClearEvents())
                 {
-                    var extractedSounds = WwiseProvider.ExtractAudioEventBorderlands4(eventName, useSoundTag);
-                    foreach (var sound in extractedSounds)
+                    foreach (var (eventName, useSoundTag) in GbxAudioUtil.GetAndClearEvents())
                     {
-                        SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                        var extractedSounds = WwiseProvider.ExtractAudioEventBorderlands4(eventName, useSoundTag);
+                        foreach (var sound in extractedSounds)
+                        {
+                            SaveAndPlaySound(cancellationToken, sound.OutputPath, sound.Extension, sound.Data, saveAudio, updateUi);
+                        }
                     }
-                }
 
-                return false;
-            }
+                    return false;
+                }
             case UWorld when isNone && UserSettings.Default.PreviewWorlds:
             case UBlueprintGeneratedClass when isNone && UserSettings.Default.PreviewWorlds && TabControl.SelectedTab.ParentExportType switch
             {
@@ -1282,46 +1310,47 @@ public class CUE4ParseViewModel : ViewModel
                                           (pkg.Name.Contains("/MI_OfferImages/", StringComparison.OrdinalIgnoreCase) ||
                                            pkg.Name.Contains("/RenderSwitch_Materials/", StringComparison.OrdinalIgnoreCase) ||
                                            pkg.Name.Contains("/MI_BPTile/", StringComparison.OrdinalIgnoreCase))):
-            {
-                if (SnooperViewer.TryLoadExport(cancellationToken, dummy, pointer.Object))
-                    SnooperViewer.Run();
-                return true;
-            }
+                {
+                    if (SnooperViewer.TryLoadExport(cancellationToken, dummy, pointer.Object))
+                        SnooperViewer.Run();
+                    return true;
+                }
             case UMaterialInstance when isNone && ModelIsOverwritingMaterial && pointer.Object.Value is UMaterialInstance m:
-            {
-                SnooperViewer.Renderer.Swap(m);
-                SnooperViewer.Run();
-                return true;
-            }
+                {
+                    SnooperViewer.Renderer.Swap(m);
+                    SnooperViewer.Run();
+                    return true;
+                }
             case UAnimSequenceBase when isNone && UserSettings.Default.PreviewAnimations || ModelIsWaitingAnimation:
-            {
-                // animate all animations using their specified skeleton or when we explicitly asked for a loaded model to be animated (ignoring whether we wanted to preview animations)
-                SnooperViewer.Renderer.Animate(pointer.Object.Value);
-                SnooperViewer.Run();
-                return true;
-            }
+                {
+                    // animate all animations using their specified skeleton or when we explicitly asked for a loaded model to be animated (ignoring whether we wanted to preview animations)
+                    SnooperViewer.Renderer.Animate(pointer.Object.Value);
+                    SnooperViewer.Run();
+                    return true;
+                }
             case UStaticMesh when HasFlag(bulk, EBulkType.Meshes):
             case USkeletalMesh when HasFlag(bulk, EBulkType.Meshes):
             case USkeleton when UserSettings.Default.SaveSkeletonAsMesh && HasFlag(bulk, EBulkType.Meshes):
             // case UMaterialInstance when HasFlag(bulk, EBulkType.Materials): // read the fucking json
             case UAnimSequenceBase when HasFlag(bulk, EBulkType.Animations):
-            {
-                SaveExport(pointer.Object.Value, updateUi);
-                return true;
-            }
+                {
+                    SaveExport(pointer.Object.Value, updateUi);
+                    return true;
+                }
             default:
-            {
-                if (!isNone && !saveTextures) return false;
+                {
+                    if (!isNone && !saveTextures)
+                        return false;
 
-                using var cPackage = new CreatorPackage(pkg.Name, dummy.ExportType, pointer.Object, UserSettings.Default.CosmeticStyle);
-                if (!cPackage.TryConstructCreator(out var creator))
-                    return false;
+                    using var cPackage = new CreatorPackage(pkg.Name, dummy.ExportType, pointer.Object, UserSettings.Default.CosmeticStyle);
+                    if (!cPackage.TryConstructCreator(out var creator))
+                        return false;
 
-                creator.ParseForInfo();
-                TabControl.SelectedTab.AddImage(pointer.Object.Value.Name, false, creator.Draw(), saveTextures, updateUi);
-                return true;
+                    creator.ParseForInfo();
+                    TabControl.SelectedTab.AddImage(pointer.Object.Value.Name, false, creator.Draw(), saveTextures, updateUi);
+                    return true;
 
-            }
+                }
         }
     }
 
@@ -1331,8 +1360,10 @@ public class CUE4ParseViewModel : ViewModel
 
         var package = Provider.LoadPackage(entry);
 
-        if (TabControl.CanAddTabs) TabControl.AddTab(entry);
-        else TabControl.SelectedTab.SoftReset(entry);
+        if (TabControl.CanAddTabs)
+            TabControl.AddTab(entry);
+        else
+            TabControl.SelectedTab.SoftReset(entry);
 
         TabControl.SelectedTab.TitleExtra = "Metadata";
         TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("");
@@ -1343,7 +1374,7 @@ public class CUE4ParseViewModel : ViewModel
     public void FindReferences(GameFile entry)
     {
         var refs = Provider.ScanForPackageRefs(entry);
-        Application.Current.Dispatcher.Invoke(delegate
+        Dispatcher.UIThread.Post(delegate
         {
             var refView = Helper.GetWindow<SearchView>("Search For Packages", () => new SearchView().Show());
             refView.ChangeCollection(ESearchViewTab.RefView, refs, entry);
@@ -1356,8 +1387,10 @@ public class CUE4ParseViewModel : ViewModel
     {
         ApplicationService.ApplicationView.IsAssetsExplorerVisible = false;
 
-        if (TabControl.CanAddTabs) TabControl.AddTab(entry);
-        else TabControl.SelectedTab.SoftReset(entry);
+        if (TabControl.CanAddTabs)
+            TabControl.AddTab(entry);
+        else
+            TabControl.SelectedTab.SoftReset(entry);
 
         TabControl.SelectedTab.TitleExtra = "Decompiled";
         TabControl.SelectedTab.Highlighter = AvalonExtensions.HighlighterSelector("cpp");
@@ -1401,7 +1434,8 @@ public class CUE4ParseViewModel : ViewModel
 
     private void SaveAndPlaySound(CancellationToken cancellationToken, string fullPath, string ext, byte[] data, bool isBulk, bool updateUi)
     {
-        if (fullPath.StartsWith('/')) fullPath = fullPath[1..];
+        if (fullPath.StartsWith('/'))
+            fullPath = fullPath[1..];
         var savedAudioPath = Path.Combine(UserSettings.Default.AudioDirectory,
             UserSettings.Default.KeepDirectoryStructure ? fullPath : fullPath.SubstringAfterLast('/')).Replace('\\', '/') + $".{ext.ToLowerInvariant()}";
 
@@ -1446,11 +1480,9 @@ public class CUE4ParseViewModel : ViewModel
             return;
         }
 
-        // TODO
-        // since we are currently in a thread, the audio player's lifetime (memory-wise) will keep the current thread up and running until fmodel itself closes
-        // the solution would be to kill the current thread at this line and then open the audio player without "Application.Current.Dispatcher.Invoke"
-        // but the ThreadWorkerViewModel is an idiot and doesn't understand we want to kill the current thread inside the current thread and continue the code
-        Application.Current.Dispatcher.Invoke(delegate
+        // Post to the UI thread so the background worker thread is not blocked for the
+        // lifetime of the audio player window (the original Invoke comment noted this issue).
+        Dispatcher.UIThread.Post(delegate
         {
             var audioPlayer = Helper.GetWindow<AudioPlayer>("Audio Player", () => new AudioPlayer().Show());
             audioPlayer.Load(data, savedAudioPath);
@@ -1480,7 +1512,7 @@ public class CUE4ParseViewModel : ViewModel
         }
     }
 
-    private readonly object _rawData = new ();
+    private readonly object _rawData = new();
     public void ExportData(GameFile entry, bool updateUi = true)
     {
         if (Provider.TrySavePackage(entry, out var assets))

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -115,42 +115,52 @@ public class CUE4ParseViewModel : ViewModel
     }
 
     public bool IsSnooperOpen => _snooper is { Exists: true, IsVisible: true };
-    private Snooper _snooper;
+    private volatile Snooper _snooper;
+    private readonly object _snooperLock = new();
     public Snooper SnooperViewer
     {
         get
         {
+            // Fast path: no locking needed once the instance exists (volatile read).
             if (_snooper != null)
                 return _snooper;
 
-            // Create the OpenTK game window on the UI thread; use CheckAccess so that a
-            // UI-thread caller (e.g. MenuCommand) does not deadlock on InvokeAsync.
-            Snooper MakeSnooper()
+            // Slow path: guard against two background threads concurrently racing
+            // through the null check and each creating a Snooper instance.
+            lock (_snooperLock)
             {
-                var scale = ImGuiController.GetDpiScale();
-                var htz = Snooper.GetMaxRefreshFrequency();
-                return _snooper = new Snooper(
-                    new GameWindowSettings { UpdateFrequency = htz },
-                    new NativeWindowSettings
-                    {
-                        ClientSize = new OpenTK.Mathematics.Vector2i(
-                            Convert.ToInt32(SystemParameters.MaximizedPrimaryScreenWidth * .75 * scale),
-                            Convert.ToInt32(SystemParameters.MaximizedPrimaryScreenHeight * .85 * scale)),
-                        NumberOfSamples = Constants.SAMPLES_COUNT,
-                        WindowBorder = WindowBorder.Resizable,
-                        Flags = ContextFlags.ForwardCompatible,
-                        Profile = ContextProfile.Core,
-                        Vsync = VSyncMode.Adaptive,
-                        APIVersion = new Version(4, 6),
-                        StartVisible = false,
-                        StartFocused = false,
-                        Title = "3D Viewer"
-                    });
-            }
+                if (_snooper != null)
+                    return _snooper;
 
-            return Dispatcher.UIThread.CheckAccess()
-                ? MakeSnooper()
-                : Dispatcher.UIThread.InvokeAsync(MakeSnooper).GetAwaiter().GetResult();
+                // Create the OpenTK game window on the UI thread; use CheckAccess so that a
+                // UI-thread caller (e.g. MenuCommand) does not deadlock on InvokeAsync.
+                Snooper MakeSnooper()
+                {
+                    var scale = ImGuiController.GetDpiScale();
+                    var htz = Snooper.GetMaxRefreshFrequency();
+                    return _snooper = new Snooper(
+                        new GameWindowSettings { UpdateFrequency = htz },
+                        new NativeWindowSettings
+                        {
+                            ClientSize = new OpenTK.Mathematics.Vector2i(
+                                Convert.ToInt32(SystemParameters.MaximizedPrimaryScreenWidth * .75 * scale),
+                                Convert.ToInt32(SystemParameters.MaximizedPrimaryScreenHeight * .85 * scale)),
+                            NumberOfSamples = Constants.SAMPLES_COUNT,
+                            WindowBorder = WindowBorder.Resizable,
+                            Flags = ContextFlags.ForwardCompatible,
+                            Profile = ContextProfile.Core,
+                            Vsync = VSyncMode.Adaptive,
+                            APIVersion = new Version(4, 6),
+                            StartVisible = false,
+                            StartFocused = false,
+                            Title = "3D Viewer"
+                        });
+                }
+
+                return Dispatcher.UIThread.CheckAccess()
+                    ? MakeSnooper()
+                    : Dispatcher.UIThread.InvokeAsync(MakeSnooper).GetAwaiter().GetResult();
+            }
         }
     }
 

--- a/FModel/ViewModels/GameDirectoryViewModel.cs
+++ b/FModel/ViewModels/GameDirectoryViewModel.cs
@@ -3,8 +3,8 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Windows;
 using System.Windows.Data;
+using Avalonia.Threading;
 using CUE4Parse.Compression;
 using CUE4Parse.UE4.IO;
 using CUE4Parse.UE4.Objects.Core.Misc;
@@ -74,7 +74,7 @@ public class FileItem : ViewModel
     public CompressionMethod[] CompressionMethods
     {
         get => _compressionMethods;
-        set => SetProperty(ref  _compressionMethods, value);
+        set => SetProperty(ref _compressionMethods, value);
     }
 
     public FileItem(string name, long length)
@@ -118,15 +118,17 @@ public class GameDirectoryViewModel : ViewModel
 
     public void Add(IAesVfsReader reader)
     {
-        if (!_hiddenArchives.IsMatch(reader.Name)) return;
+        if (!_hiddenArchives.IsMatch(reader.Name))
+            return;
 
         var fileItem = new FileItem(reader);
-        Application.Current.Dispatcher.Invoke(() => DirectoryFiles.Add(fileItem));
+        Dispatcher.UIThread.Post(() => DirectoryFiles.Add(fileItem));
     }
 
     public void Verify(IAesVfsReader reader)
     {
-        if (DirectoryFiles.FirstOrDefault(x => x.Name == reader.Name) is not { } file) return;
+        if (DirectoryFiles.FirstOrDefault(x => x.Name == reader.Name) is not { } file)
+            return;
 
         file.IsEnabled = true;
         file.MountPoint = reader.MountPoint;
@@ -135,7 +137,8 @@ public class GameDirectoryViewModel : ViewModel
 
     public void Disable(IAesVfsReader reader)
     {
-        if (DirectoryFiles.FirstOrDefault(x => x.Name == reader.Name) is not { } file) return;
+        if (DirectoryFiles.FirstOrDefault(x => x.Name == reader.Name) is not { } file)
+            return;
         file.IsEnabled = false;
     }
 }

--- a/FModel/ViewModels/TabControlViewModel.cs
+++ b/FModel/ViewModels/TabControlViewModel.cs
@@ -6,6 +6,7 @@ using FModel.ViewModels.Commands;
 using FModel.Views.Resources.Controls;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Highlighting;
+using Avalonia.Threading;
 using Serilog;
 using SkiaSharp;
 using System.Collections.ObjectModel;
@@ -281,7 +282,7 @@ public class TabItem : ViewModel
         TitleExtra = string.Empty;
         ParentExportType = string.Empty;
         ScrollTrigger = null;
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             _images.Clear();
             SelectedImage = null;
@@ -331,7 +332,7 @@ public class TabItem : ViewModel
 
     public void AddImage(string name, bool rnn, CTexture img, bool save, bool updateUi)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             var t = new TabImage(name, rnn, img);
             if (save)
@@ -348,7 +349,7 @@ public class TabItem : ViewModel
 
     public void AddImage(string name, bool rnn, SKBitmap img, bool save, bool updateUi)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             var t = new TabImage(name, rnn, img);
             if (save)
@@ -368,7 +369,7 @@ public class TabItem : ViewModel
 
     public void SetDocumentText(string text, bool save, bool updateUi)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             Document ??= new TextDocument();
             Document.Text = text;
@@ -412,7 +413,7 @@ public class TabItem : ViewModel
 
         Directory.CreateDirectory(directory.SubstringBeforeLast('/'));
 
-        Application.Current.Dispatcher.Invoke(() => File.WriteAllText(directory, Document.Text));
+        Dispatcher.UIThread.Invoke(() => File.WriteAllText(directory, Document.Text));
         SaveCheck(directory, fileName, updateUi);
     }
 
@@ -476,7 +477,7 @@ public class TabControlViewModel : ViewModel
 
         if (!CanAddTabs)
             return;
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             _tabItems.Add(new TabItem(entry, parentExportType ?? string.Empty));
             SelectedTab = _tabItems.Last();
@@ -485,7 +486,7 @@ public class TabControlViewModel : ViewModel
 
     public void RemoveTab(TabItem tab = null)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             var tabCount = _tabItems.Count;
             var tabToDelete = tab ?? SelectedTab;
@@ -520,7 +521,7 @@ public class TabControlViewModel : ViewModel
 
     public void RemoveOtherTabs(TabItem tab)
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             foreach (var t in _tabItems.Where(t => t != tab).ToList())
             {
@@ -531,7 +532,7 @@ public class TabControlViewModel : ViewModel
 
     public void RemoveAllTabs()
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        Dispatcher.UIThread.Invoke(() =>
         {
             SelectedTab = null;
             _tabItems.Clear();

--- a/FModel/Views/Resources/Controls/EndpointEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/EndpointEditor.xaml.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
-using System.Windows;
 using System.Windows.Controls;
+using Avalonia.Threading;
 using FModel.Extensions;
 using FModel.Services;
 using FModel.Settings;
@@ -60,7 +60,7 @@ public partial class EndpointEditor
             return;
 
         var body = await ApplicationService.ApiEndpointView.DynamicApi.GetRequestBody(default, endpoint.Url).ConfigureAwait(false);
-        Application.Current.Dispatcher.Invoke(delegate
+        Dispatcher.UIThread.Post(delegate
         {
             EndpointResponse.Document ??= new TextDocument();
             EndpointResponse.Document.Text = body.ToString(Formatting.Indented);

--- a/FModel/Views/Snooper/Renderer.cs
+++ b/FModel/Views/Snooper/Renderer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
-using System.Windows;
+using Avalonia.Threading;
 using CUE4Parse_Conversion.Animations;
 using CUE4Parse_Conversion.Meshes;
 using CUE4Parse.UE4.Assets.Exports;
@@ -115,10 +115,11 @@ public class Renderer : IDisposable
 
     public void Swap(UMaterialInstance unrealMaterial)
     {
-        if (!Options.TryGetModel(out var model) || !Options.TryGetSection(model, out var section)) return;
+        if (!Options.TryGetModel(out var model) || !Options.TryGetSection(model, out var section))
+            return;
 
         model.Materials[section.MaterialIndex].SwapMaterial(unrealMaterial);
-        Application.Current.Dispatcher.Invoke(() => model.Materials[section.MaterialIndex].Setup(Options, model.UvCount));
+        Dispatcher.UIThread.Invoke(() => model.Materials[section.MaterialIndex].Setup(Options, model.UvCount));
     }
 
     public void Animate(UObject anim)
@@ -133,12 +134,14 @@ public class Renderer : IDisposable
                 {
                     // do nothing, selected model has the correct skeleton for this animation
                 }
-                else */if (animBase.Skeleton.TryLoad(out USkeleton skeleton))
+                else */
+                if (animBase.Skeleton.TryLoad(out USkeleton skeleton))
                 {
                     LoadSkeleton(skeleton);
                 }
             }
-            else return; // should never end here
+            else
+                return; // should never end here
         }
 
         Animate(anim, Options.SelectedModel);
@@ -179,29 +182,29 @@ public class Renderer : IDisposable
             switch (export)
             {
                 case UStaticMesh st:
-                {
-                    guid = st.LightingGuid;
-                    if (Options.TryGetModel(guid, out addedModel))
                     {
-                        addedModel.AddInstance(t);
+                        guid = st.LightingGuid;
+                        if (Options.TryGetModel(guid, out addedModel))
+                        {
+                            addedModel.AddInstance(t);
+                        }
+                        else if (st.TryConvert(out var mesh))
+                        {
+                            addedModel = new StaticModel(st, mesh, t);
+                            Options.Models[guid] = addedModel;
+                        }
+                        break;
                     }
-                    else if (st.TryConvert(out var mesh))
-                    {
-                        addedModel = new StaticModel(st, mesh, t);
-                        Options.Models[guid] = addedModel;
-                    }
-                    break;
-                }
                 case USkeletalMesh sk:
-                {
-                    guid = Guid.NewGuid();
-                    if (!Options.Models.ContainsKey(guid) && sk.TryConvert(out var mesh))
                     {
-                        addedModel = new SkeletalModel(sk, mesh, t);
-                        Options.Models[guid] = addedModel;
+                        guid = Guid.NewGuid();
+                        if (!Options.Models.ContainsKey(guid) && sk.TryConvert(out var mesh))
+                        {
+                            addedModel = new SkeletalModel(sk, mesh, t);
+                            Options.Models[guid] = addedModel;
+                        }
+                        break;
                     }
-                    break;
-                }
             }
 
             if (addedModel == null)
@@ -251,8 +254,10 @@ public class Renderer : IDisposable
         var viewMatrix = CameraOp.GetViewMatrix();
         var projMatrix = CameraOp.GetProjectionMatrix();
 
-        if (ShowSkybox) _skybox.Render(viewMatrix, projMatrix);
-        if (ShowGrid) _grid.Render(viewMatrix, projMatrix, CameraOp.Near, CameraOp.Far);
+        if (ShowSkybox)
+            _skybox.Render(viewMatrix, projMatrix);
+        if (ShowGrid)
+            _grid.Render(viewMatrix, projMatrix, CameraOp.Near, CameraOp.Far);
 
         _shader.Render(viewMatrix, CameraOp.Position, projMatrix);
         for (int i = 0; i < 5; i++)
@@ -261,7 +266,8 @@ public class Renderer : IDisposable
         // render model pass
         foreach (var model in Options.Models.Values)
         {
-            if (!model.IsVisible) continue;
+            if (!model.IsVisible)
+                continue;
             model.Render(_shader, Color == VertexColor.TextureCoordinates ? Options.Icons["checker"] : null);
         }
 
@@ -302,13 +308,15 @@ public class Renderer : IDisposable
 
     public void Update(Snooper wnd, float deltaSeconds)
     {
-        if (Options.Animations.Count > 0) Options.Tracker.Update(deltaSeconds);
+        if (Options.Animations.Count > 0)
+            Options.Tracker.Update(deltaSeconds);
         foreach (var animation in Options.Animations)
         {
             animation.TimeCalculation(Options.Tracker.ElapsedTime);
             foreach (var guid in animation.AttachedModels)
             {
-                if (!Options.TryGetModel(guid, out var m) || m is not SkeletalModel skeletalModel) continue;
+                if (!Options.TryGetModel(guid, out var m) || m is not SkeletalModel skeletalModel)
+                    continue;
                 skeletalModel.Skeleton.UpdateAnimationMatrices(animation, AnimateWithRotationOnly);
             }
         }
@@ -350,7 +358,7 @@ public class Renderer : IDisposable
         if (Options.TryGetModel(guid, out var model))
         {
             model.AddInstance(Transform.Identity);
-            Application.Current.Dispatcher.Invoke(() => model.SetupInstances());
+            Dispatcher.UIThread.Invoke(() => model.SetupInstances());
             return;
         }
 
@@ -364,7 +372,8 @@ public class Renderer : IDisposable
     private void LoadSkeletalMesh(USkeletalMesh original)
     {
         var guid = new FGuid((uint) original.GetFullName().GetHashCode());
-        if (Options.Models.ContainsKey(guid) || !original.TryConvert(out var mesh)) return;
+        if (Options.Models.ContainsKey(guid) || !original.TryConvert(out var mesh))
+            return;
 
         var skeletalModel = new SkeletalModel(original, mesh);
         Options.Models[guid] = skeletalModel;
@@ -374,7 +383,8 @@ public class Renderer : IDisposable
     private void LoadSkeleton(USkeleton original)
     {
         var guid = original.Guid;
-        if (Options.Models.ContainsKey(guid) || !original.TryConvert(out _, out var box)) return;
+        if (Options.Models.ContainsKey(guid) || !original.TryConvert(out _, out var box))
+            return;
 
         var fakeSkeletalModel = new SkeletalModel(original, box);
         Options.Models[guid] = fakeSkeletalModel;
@@ -391,7 +401,7 @@ public class Renderer : IDisposable
         if (Options.TryGetModel(guid, out var model))
         {
             model.Materials[0].SwapMaterial(original);
-            Application.Current.Dispatcher.Invoke(() => model.Materials[0].Setup(Options, model.UvCount));
+            Dispatcher.UIThread.Invoke(() => model.Materials[0].Setup(Options, model.UvCount));
             return;
         }
 
@@ -411,7 +421,7 @@ public class Renderer : IDisposable
         if (Options.TryGetModel(guid, out var model))
         {
             model.AddInstance(Transform.Identity);
-            Application.Current.Dispatcher.Invoke(() => model.SetupInstances());
+            Dispatcher.UIThread.Invoke(() => model.SetupInstances());
             return;
         }
 
@@ -476,15 +486,16 @@ public class Renderer : IDisposable
             cancellationToken.ThrowIfCancellationRequested();
 
             IPropertyHolder actor;
-            if (allNodes is {Length: > 0} && allNodes[i].TryLoad(out UObject node))
+            if (allNodes is { Length: > 0 } && allNodes[i].TryLoad(out UObject node))
             {
                 actor = node;
             }
-            else if (records is {Length: > 0})
+            else if (records is { Length: > 0 })
             {
                 actor = records[i];
             }
-            else continue;
+            else
+                continue;
 
             Services.ApplicationService.ApplicationView.Status.UpdateStatusLabel($"{original.Name} ... {i}/{length}");
             WorldMesh(actor, transform, true);
@@ -503,7 +514,8 @@ public class Renderer : IDisposable
     private void WorldCamera(UObject actor)
     {
         if (actor.ExportType != "LevelBounds" || !actor.TryGetValue(out FPackageIndex boxComponent, "BoxComponent") ||
-            boxComponent.Load() is not { } boxObject) return;
+            boxComponent.Load() is not { } boxObject)
+            return;
 
         var direction = boxObject.GetOrDefault("RelativeLocation", FVector.ZeroVector) * Constants.SCALE_DOWN_RATIO;
         var position = boxObject.GetOrDefault("RelativeScale3D", FVector.OneVector) / 2f * Constants.SCALE_DOWN_RATIO;
@@ -513,7 +525,8 @@ public class Renderer : IDisposable
     private void WorldLight(UObject actor)
     {
         if (!actor.TryGetValue(out FPackageIndex lightComponent, "LightComponent") ||
-            lightComponent.Load() is not { } lightObject) return;
+            lightComponent.Load() is not { } lightObject)
+            return;
 
         switch (actor.ExportType)
         {
@@ -555,7 +568,8 @@ public class Renderer : IDisposable
                         });
                     }
                 }
-                else ProcessMesh(actor, staticMeshComp, m, relation);
+                else
+                    ProcessMesh(actor, staticMeshComp, m, relation);
             }
         }
         else if (actor.TryGetValue(out FPackageIndex componentTemplate, "ComponentTemplate") &&
@@ -596,11 +610,11 @@ public class Renderer : IDisposable
         {
             model.AddInstance(transform);
             if (bSpline && model is SplineModel splineModel)
-                splineModel.AddComponent((USplineMeshComponent)staticMeshComp);
+                splineModel.AddComponent((USplineMeshComponent) staticMeshComp);
         }
         else if (m.TryConvert(out var mesh, UserSettings.Default.NaniteMeshExportFormat))
         {
-            model = bSpline ? new SplineModel(m, mesh, (USplineMeshComponent)staticMeshComp, transform) : new StaticModel(m, mesh, transform);
+            model = bSpline ? new SplineModel(m, mesh, (USplineMeshComponent) staticMeshComp, transform) : new StaticModel(m, mesh, transform);
             model.IsTwoSided = actor.GetOrDefault("bMirrored", staticMeshComp.GetOrDefault("bDisallowMeshPaintPerInstance", model.IsTwoSided));
 
             if (actor.TryGetAllValues(out FPackageIndex[] textureData, "TextureData"))
@@ -645,7 +659,8 @@ public class Renderer : IDisposable
                 {
                     var matIndex = model.Sections[j].MaterialIndex;
                     if (matIndex < 0 || matIndex >= model.Materials.Length || matIndex >= overrideMaterials.Length ||
-                        overrideMaterials[matIndex].Load() is not UMaterialInterface unrealMaterial) continue;
+                        overrideMaterials[matIndex].Load() is not UMaterialInterface unrealMaterial)
+                        continue;
 
                     model.Materials[matIndex].SwapMaterial(unrealMaterial);
                 }
@@ -702,7 +717,8 @@ public class Renderer : IDisposable
             {
                 ref var vertexColor = ref staticMesh.RenderData.LODs[0].ColorVertexBuffer.Data[i];
                 var indexAsByte = vertexColor.R;
-                if (indexAsByte == 255) indexAsByte = vertexColor.A;
+                if (indexAsByte == 255)
+                    indexAsByte = vertexColor.A;
                 distinctReds.Add(indexAsByte);
             }
 
@@ -721,9 +737,11 @@ public class Renderer : IDisposable
                 dico[indexAsByte] = color.ToFColor(true);
             }
         }
-        else foreach (var material in geometryCollection.Materials)
+        else
+        foreach (var material in geometryCollection.Materials)
         {
-            if (!material.TryLoad(out UMaterialInterface unrealMaterial)) continue;
+            if (!material.TryLoad(out UMaterialInterface unrealMaterial))
+                continue;
 
             var parameters = new CMaterialParams2();
             unrealMaterial.GetParams(parameters, EMaterialFormat.FirstLayer);
@@ -751,7 +769,8 @@ public class Renderer : IDisposable
         for (var lod = 0; lod < staticMeshComp.LODData.Length; lod++)
         {
             var vertexColors = staticMeshComp.LODData[lod].OverrideVertexColors;
-            if (vertexColors == null) continue;
+            if (vertexColors == null)
+                continue;
 
             staticMesh.RenderData.LODs[lod].ColorVertexBuffer = vertexColors;
         }
@@ -795,7 +814,8 @@ public class Renderer : IDisposable
         Options.SwapMaterial(false);
         Options.AnimateMesh(false);
 
-        if (_saveCameraMode) UserSettings.Default.CameraMode = CameraOp.Mode;
+        if (_saveCameraMode)
+            UserSettings.Default.CameraMode = CameraOp.Mode;
         UserSettings.Default.ShowSkybox = ShowSkybox;
         UserSettings.Default.ShowGrid = ShowGrid;
         UserSettings.Default.AnimateWithRotationOnly = AnimateWithRotationOnly;

--- a/FModel/Views/Snooper/Snooper.cs
+++ b/FModel/Views/Snooper/Snooper.cs
@@ -9,6 +9,7 @@ using OpenTK.Graphics.OpenGL4;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Common.Input;
 using OpenTK.Windowing.Desktop;
+using Avalonia.Threading;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
@@ -62,7 +63,9 @@ public class Snooper : GameWindow
     {
         Renderer.Options.SwapMaterial(false);
         Renderer.Options.AnimateMesh(false);
-        Application.Current.Dispatcher.Invoke(delegate
+        // Post the game loop to the UI thread so the calling (background) thread
+        // is not blocked for the lifetime of the 3D viewer window.
+        Dispatcher.UIThread.Post(delegate
         {
             WindowShouldClose(false, false);
             base.Run();

--- a/FModel/Views/Snooper/Snooper.cs
+++ b/FModel/Views/Snooper/Snooper.cs
@@ -63,13 +63,20 @@ public class Snooper : GameWindow
     {
         Renderer.Options.SwapMaterial(false);
         Renderer.Options.AnimateMesh(false);
-        // Post the game loop to the UI thread so the calling (background) thread
-        // is not blocked for the lifetime of the 3D viewer window.
-        Dispatcher.UIThread.Post(delegate
-        {
-            WindowShouldClose(false, false);
-            base.Run();
-        });
+
+        // GLFW.SetWindowShouldClose is documented as callable from any thread.
+        unsafe
+        { GLFW.SetWindowShouldClose(WindowPtr, false); }
+
+        // glfwShowWindow must be called from the GLFW main thread (the thread that
+        // created the window, which is the Avalonia UI thread).
+        Dispatcher.UIThread.Post(() => IsVisible = true);
+
+        // Run the blocking GLFW game loop on a dedicated background thread so that
+        // neither the calling thread nor the Avalonia UI event loop is blocked for
+        // the lifetime of the 3D viewer window. OpenTK transfers the GL context to
+        // this thread via Context.MakeCurrent() at the start of base.Run().
+        new Thread(() => base.Run()) { IsBackground = true, Name = "Snooper-GameLoop" }.Start();
     }
 
     private unsafe void LoadWindowIcon()

--- a/FModel/Views/Snooper/Snooper.cs
+++ b/FModel/Views/Snooper/Snooper.cs
@@ -49,14 +49,16 @@ public class Snooper : GameWindow
             Renderer.Save();
         }
 
+        // GLFW.SetWindowShouldClose is thread-safe; IsVisible (glfwShowWindow/
+        // glfwHideWindow) must be called from the GLFW main thread (UI thread).
         GLFW.SetWindowShouldClose(WindowPtr, value); // start / stop game loop
-        IsVisible = !value;
+        Dispatcher.UIThread.Post(() => IsVisible = !value);
     }
 
     public unsafe void WindowShouldFreeze(bool value)
     {
         GLFW.SetWindowShouldClose(WindowPtr, value); // start / stop game loop
-        IsVisible = true;
+        Dispatcher.UIThread.Post(() => IsVisible = true);
     }
 
     public override void Run()


### PR DESCRIPTION
## Summary

Resolves #25 — replaces **all** `Application.Current.Dispatcher.Invoke()` / `BeginInvoke()` calls with `Avalonia.Threading.Dispatcher.UIThread` equivalents so that cross-thread UI operations work on Linux without a WPF dependency.

`CustomRichTextBox.cs` was already fully migrated and required no changes.

`GameFileViewModel.cs` is intentionally excluded: its single `InvokeAsync` call is inseparable from the `System.Windows.Media.ImageSource` / `BitmapImage` types on which it operates; migrating it requires a separate image-type migration ticket.

---

## Files Changed

### Commit 1 — initial migration of the 3 files listed in issue #25

| File | Calls | Strategy |
|------|-------|----------|
| `ViewModels/AudioPlayerViewModel.cs` | 7 | `Post` (fire-and-forget UI mutations) |
| `ViewModels/CUE4ParseViewModel.cs` | 3 | `Post` / `CheckAccess+InvokeAsync` |
| `Views/Snooper/Snooper.cs` | 1 | `Post` |

### Commit 2 — fix review findings + complete migration of remaining files

#### Review findings fixed

**[C1 — Critical]** `Load()` wrapped in `Post()` silently broke every `Load() → Play()` call sequence.
All callers of `Load()` are on the UI thread (ICommand, key handlers, enclosing `Post` lambdas). `Post()` always defers even from the UI thread, so the immediately-following `Play()` found `_soundOut == null` and silently returned. Fixed by removing the `Post` wrapper so `Load()` runs synchronously — matching the WPF `Dispatcher.Invoke` re-entrant-from-dispatcher-thread behaviour.

**[M1 — Major]** `Dispose()` as `Post()` risked leaked resources and a timer/dispose race.
`_sourceTimer` ticks every 10 ms on a threadpool thread. With deferred disposal there was a wide race window for use-after-dispose. Also, if the event loop shut down before the queued `Post` ran, `_waveSource`/`_soundOut` would never be disposed. Fixed by calling `_sourceTimer.Change(Infinite, Infinite)` synchronously first, then disposing everything inline (`Dispose()` is always called from `OnClosing`, which fires on the UI thread).

**[M2 — Major]** `Snooper.Run()` posted the blocking GLFW game loop to the Avalonia UI thread, freezing the entire application for the lifetime of the 3D viewer window. The Win32 shared message-pump trick that allowed this to "work" on WPF does not apply to Avalonia on Linux. Fixed:
- `GLFW.SetWindowShouldClose` (thread-safe per GLFW docs) — called from calling thread
- `IsVisible = true` (requires GLFW main/creating thread) — posted to UI thread
- `base.Run()` — started on a new `IsBackground = true` thread named `Snooper-GameLoop`; OpenTK transfers the GL context via `Context.MakeCurrent()` at the start of `Run()`

**[m1 — Minor]** `SnooperViewer` getter had no lock: two concurrent background threads could both see `_snooper == null`, both invoke `MakeSnooper`, and the second would overwrite and leak the first `Snooper`. Fixed with `volatile` field + double-checked lock (`_snooperLock`) around the slow path.

#### Remaining files (addresses reviewer comment)

| File | Calls | Strategy |
|------|-------|----------|
| `ViewModels/BackupManagerViewModel.cs` | 1 | `Post` |
| `ViewModels/AssetsFolderViewModel.cs` | 3 | `CheckAccess` + `InvokeAsync.GetAwaiter().GetResult()`; `Post` |
| `ViewModels/TabControlViewModel.cs` | 8 | `Invoke` (synchronous — callers depend on completion) |
| `ViewModels/GameDirectoryViewModel.cs` | 1 | `Post` |
| `Views/Snooper/Renderer.cs` | 3 | `Invoke` (synchronous — callers depend on GL setup completing) |
| `Views/Resources/Controls/EndpointEditor.xaml.cs` | 1 | `Post` |

---

## Threading Design Notes

| Site | WPF | Avalonia | Reason |
|------|-----|----------|--------|
| `AudioPlayerViewModel.Load()` | `Invoke` (sync, re-entrant no-op from UI thread) | Direct (no dispatch) | All callers are already on UI thread |
| `AudioPlayerViewModel.AddToPlaylist/Remove/Replace/SavePlaylist` | `Invoke` (sync) | `Post` (async) | Fire-and-forget UI collection mutations |
| `AudioPlayerViewModel.Dispose()` | `Invoke` (sync) | Direct (no dispatch) | Called from OnClosing on UI thread; timer stopped first |
| `SnooperViewer` getter | `Invoke(Func)` (sync, returns) | `CheckAccess` + `InvokeAsync().GetAwaiter().GetResult()` | Must return a value; guard prevents UI-thread deadlock |
| `Snooper.Run()` | `Invoke` (sync, blocks caller + UI) | `Post(IsVisible=true)` + new background thread for `base.Run()` | GLFW loop must not block the Avalonia event loop |
| `FindReferences` | `Invoke` (sync) | `Post` (async) | Opens a window; fire-and-forget |
| Audio player window | `Invoke` (sync) | `Post` (async) | Opens a window; fire-and-forget |
| `TabControlViewModel.*` | `Invoke` (sync) | `Invoke` (sync) | Callers on background threads depend on completion |
| `Renderer.Swap/Load*` | `Invoke` (sync) | `Invoke` (sync) | GL resource setup must complete before caller continues |