### PR TITLE
feat(images): Migrate BitmapImage/ImageSource to Avalonia.Media.Imaging.Bitmap [P2-011]

### DIFF
--- a/.github/agents/avalonia-migration-reviewer.agent.md
+++ b/.github/agents/avalonia-migration-reviewer.agent.md
@@ -2,7 +2,13 @@
 description: Expert principal-engineer-level code reviewer for WPF-to-Avalonia migrations — checks behavioral parity, threading model, style/trigger conversions, and MVVM correctness
 name: Avalonia Migration Reviewer
 argument-hint: Point me at the files just migrated (e.g. "review FModel/Views/SettingsView.xaml and its code-behind") or say "review all recent Avalonia migration changes"
-tools: [read, search]
+tools:
+    - read
+    - search
+    - github/list_pull_requests
+    - github/pull_request_read
+    - github/issue_read
+    - github/list_issues
 handoffs:
     - label: Fix Review Findings
       agent: WPF → Avalonia Migrator

--- a/FModel/FModel.csproj
+++ b/FModel/FModel.csproj
@@ -269,10 +269,10 @@
     <Resource Include="Resources\Flat.png" />
     <Resource Include="Resources\Cataba.png" />
     <Resource Include="Resources\BurbankBigCondensed-Bold.ttf" />
-    <Resource Include="Resources\add_directory.png" />
-    <Resource Include="Resources\delete.png" />
-    <Resource Include="Resources\edit.png" />
-    <Resource Include="Resources\go_to_directory.png" />
+    <AvaloniaResource Include="Resources\add_directory.png" />
+    <AvaloniaResource Include="Resources\delete.png" />
+    <AvaloniaResource Include="Resources\edit.png" />
+    <AvaloniaResource Include="Resources\go_to_directory.png" />
     <Resource Include="Resources\npcleftside.png" />
     <Resource Include="Resources\nx.png" />
     <Resource Include="Resources\ny.png" />

--- a/FModel/ViewModels/CustomDirectoriesViewModel.cs
+++ b/FModel/ViewModels/CustomDirectoriesViewModel.cs
@@ -2,9 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using FModel.Framework;
 using FModel.Settings;
 using FModel.ViewModels.Commands;
@@ -43,7 +44,8 @@ public class CustomDirectoriesViewModel : ViewModel
 
     public void Edit(int index, CustomDirectory newDir)
     {
-        if (_directories.ElementAt(index) is not MenuItem dir) return;
+        if (_directories.ElementAt(index) is not MenuItem dir)
+            return;
 
         dir.Header = newDir.Header;
         dir.Tag = newDir.DirectoryPath;
@@ -61,7 +63,8 @@ public class CustomDirectoriesViewModel : ViewModel
         var directories = new List<CustomDirectory>();
         for (var i = 2; i < _directories.Count; i++)
         {
-            if (_directories[i] is not MenuItem m) continue;
+            if (_directories[i] is not MenuItem m)
+                continue;
             directories.Add(new CustomDirectory(m.Header.ToString(), m.Tag.ToString()));
         }
 
@@ -73,7 +76,7 @@ public class CustomDirectoriesViewModel : ViewModel
         yield return new MenuItem
         {
             Header = "Add Directory",
-            Icon = new Image { Source = new BitmapImage(new Uri("/FModel;component/Resources/add_directory.png", UriKind.Relative)) },
+            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/add_directory.png"))) },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = AddEditDirectoryCommand
@@ -101,7 +104,7 @@ public class CustomDirectoriesViewModel : ViewModel
         yield return new MenuItem
         {
             Header = "Go To",
-            Icon = new Image { Source = new BitmapImage(new Uri("/FModel;component/Resources/go_to_directory.png", UriKind.Relative)) },
+            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/go_to_directory.png"))) },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = GoToCommand,
@@ -110,7 +113,7 @@ public class CustomDirectoriesViewModel : ViewModel
         yield return new MenuItem
         {
             Header = "Edit Directory",
-            Icon = new Image { Source = new BitmapImage(new Uri("/FModel;component/Resources/edit.png", UriKind.Relative)) },
+            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/edit.png"))) },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = AddEditDirectoryCommand,
@@ -120,7 +123,7 @@ public class CustomDirectoriesViewModel : ViewModel
         {
             Header = "Delete Directory",
             StaysOpenOnClick = true,
-            Icon = new Image { Source = new BitmapImage(new Uri("/FModel;component/Resources/delete.png", UriKind.Relative)) },
+            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/delete.png"))) },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = DeleteDirectoryCommand,

--- a/FModel/ViewModels/CustomDirectoriesViewModel.cs
+++ b/FModel/ViewModels/CustomDirectoriesViewModel.cs
@@ -76,7 +76,7 @@ public class CustomDirectoriesViewModel : ViewModel
         yield return new MenuItem
         {
             Header = "Add Directory",
-            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/add_directory.png"))) },
+            Icon = new Image { Source = LoadIcon("add_directory.png") },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = AddEditDirectoryCommand
@@ -99,12 +99,18 @@ public class CustomDirectoriesViewModel : ViewModel
         }
     }
 
+    private static Bitmap LoadIcon(string filename)
+    {
+        using var stream = AssetLoader.Open(new Uri($"avares://FModel/Resources/{filename}"));
+        return new Bitmap(stream);
+    }
+
     private IEnumerable<MenuItem> EnumerateCommands(CustomDirectory dir)
     {
         yield return new MenuItem
         {
             Header = "Go To",
-            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/go_to_directory.png"))) },
+            Icon = new Image { Source = LoadIcon("go_to_directory.png") },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = GoToCommand,
@@ -113,7 +119,7 @@ public class CustomDirectoriesViewModel : ViewModel
         yield return new MenuItem
         {
             Header = "Edit Directory",
-            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/edit.png"))) },
+            Icon = new Image { Source = LoadIcon("edit.png") },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = AddEditDirectoryCommand,
@@ -123,7 +129,7 @@ public class CustomDirectoriesViewModel : ViewModel
         {
             Header = "Delete Directory",
             StaysOpenOnClick = true,
-            Icon = new Image { Source = new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/delete.png"))) },
+            Icon = new Image { Source = LoadIcon("delete.png") },
             HorizontalContentAlignment = HorizontalAlignment.Left,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = DeleteDirectoryCommand,

--- a/FModel/ViewModels/GameFileViewModel.cs
+++ b/FModel/ViewModels/GameFileViewModel.cs
@@ -392,7 +392,7 @@ public class GameFileViewModel(GameFile asset) : ViewModel
             case "bmp":
             case "svg":
                 {
-                    Resolved |= ~EResolveCompute.Preview;
+                    Resolved &= ~EResolveCompute.Preview;
                     AssetCategory = EAssetCategory.Texture;
                     AssetActions = EBulkType.Textures;
                     if (!resolve.HasFlag(EResolveCompute.Preview))
@@ -452,7 +452,6 @@ public class GameFileViewModel(GameFile asset) : ViewModel
     private void SetPreviewImage(SKData data)
     {
         using var ms = new MemoryStream(data.ToArray());
-        ms.Position = 0;
 
         // Bitmap reads the stream to an internal buffer during construction;
         // it is safe to construct on a background thread and assign on the UI thread.

--- a/FModel/ViewModels/GameFileViewModel.cs
+++ b/FModel/ViewModels/GameFileViewModel.cs
@@ -2,9 +2,8 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 
 using CUE4Parse.FileProvider.Objects;
 using CUE4Parse.GameTypes.Borderlands3.Assets.Exports;
@@ -107,8 +106,8 @@ public class GameFileViewModel(GameFile asset) : ViewModel
         }
     }
 
-    private ImageSource _previewImage;
-    public ImageSource PreviewImage
+    private Bitmap _previewImage;
+    public Bitmap PreviewImage
     {
         get => _previewImage;
         private set
@@ -190,8 +189,10 @@ public class GameFileViewModel(GameFile asset) : ViewModel
                 throw new InvalidOperationException($"Failed to load {Asset.Path} as UE package.");
 
             var mainIndex = pkg.GetExportIndex(Asset.NameWithoutExtension, StringComparison.OrdinalIgnoreCase);
-            if (mainIndex < 0) mainIndex = pkg.GetExportIndex($"{Asset.NameWithoutExtension}_C", StringComparison.OrdinalIgnoreCase);
-            if (mainIndex < 0) mainIndex = 0;
+            if (mainIndex < 0)
+                mainIndex = pkg.GetExportIndex($"{Asset.NameWithoutExtension}_C", StringComparison.OrdinalIgnoreCase);
+            if (mainIndex < 0)
+                mainIndex = 0;
 
             var pointer = new FPackageIndex(pkg, mainIndex + 1).ResolvedObject;
             if (pointer?.Object is null)
@@ -269,29 +270,30 @@ public class GameFileViewModel(GameFile asset) : ViewModel
             switch (AssetCategory)
             {
                 case EAssetCategory.Texture when pointer.Object.Value is UTexture texture:
-                {
-                    if (!resolve.HasFlag(EResolveCompute.Preview))
-                        break;
-
-                    if (pointer.Object.Value is UTexture2DArray textureArray && textureArray.GetFirstMip() is { SizeZ: > 1 } firstMip)
-                        NumTextures = firstMip.SizeZ;
-
-                    var img = texture.Decode(MaxPreviewSize, UserSettings.Default.CurrentDir.TexturePlatform);
-                    if (img != null)
                     {
-                        using var bitmap = img.ToSkBitmap();
-                        using var image = bitmap.Encode(SKEncodedImageFormat.Png, 100);
-                        SetPreviewImage(image);
+                        if (!resolve.HasFlag(EResolveCompute.Preview))
+                            break;
+
+                        if (pointer.Object.Value is UTexture2DArray textureArray && textureArray.GetFirstMip() is { SizeZ: > 1 } firstMip)
+                            NumTextures = firstMip.SizeZ;
+
+                        var img = texture.Decode(MaxPreviewSize, UserSettings.Default.CurrentDir.TexturePlatform);
+                        if (img != null)
+                        {
+                            using var bitmap = img.ToSkBitmap();
+                            using var image = bitmap.Encode(SKEncodedImageFormat.Png, 100);
+                            SetPreviewImage(image);
+                        }
+                        break;
                     }
-                    break;
-                }
                 case EAssetCategory.ItemDefinitionBase:
                     if (!resolve.HasFlag(EResolveCompute.Preview))
                         break;
 
                     if (pointer.Object.Value is UItemDefinitionBase itemDef)
                     {
-                        if (LookupPreview(itemDef.DataList)) break;
+                        if (LookupPreview(itemDef.DataList))
+                            break;
 
                         if (itemDef is UAthenaPickaxeItemDefinition pickaxe && pickaxe.WeaponDefinition.TryLoad(out UItemDefinitionBase weaponDef))
                         {
@@ -307,7 +309,8 @@ public class GameFileViewModel(GameFile asset) : ViewModel
                                     continue;
 
                                 var img = texture.Decode(MaxPreviewSize, UserSettings.Default.CurrentDir.TexturePlatform);
-                                if (img == null) return false;
+                                if (img == null)
+                                    return false;
 
                                 using var bitmap = img.ToSkBitmap();
                                 using var image = bitmap.Encode(SKEncodedImageFormat.Png, 100);
@@ -388,48 +391,48 @@ public class GameFileViewModel(GameFile asset) : ViewModel
             case "png":
             case "bmp":
             case "svg":
-            {
-                Resolved |= ~EResolveCompute.Preview;
-                AssetCategory = EAssetCategory.Texture;
-                AssetActions = EBulkType.Textures;
-                if (!resolve.HasFlag(EResolveCompute.Preview))
-                    break;
-
-                return Task.Run(() =>
                 {
-                    var data = _applicationView.CUE4Parse.Provider.SaveAsset(Asset);
-                    using var stream = new MemoryStream(data);
-                    stream.Position = 0;
+                    Resolved |= ~EResolveCompute.Preview;
+                    AssetCategory = EAssetCategory.Texture;
+                    AssetActions = EBulkType.Textures;
+                    if (!resolve.HasFlag(EResolveCompute.Preview))
+                        break;
 
-                    SKBitmap bitmap;
-                    if (lowercaseExtension == "svg")
+                    return Task.Run(() =>
                     {
-                        var svg = new SKSvg();
-                        svg.Load(stream);
-                        if (svg.Picture == null)
-                            return;
+                        var data = _applicationView.CUE4Parse.Provider.SaveAsset(Asset);
+                        using var stream = new MemoryStream(data);
+                        stream.Position = 0;
 
-                        bitmap = new SKBitmap(MaxPreviewSize, MaxPreviewSize);
-                        using var canvas = new SKCanvas(bitmap);
-                        canvas.Clear(SKColors.Transparent);
+                        SKBitmap bitmap;
+                        if (lowercaseExtension == "svg")
+                        {
+                            var svg = new SKSvg();
+                            svg.Load(stream);
+                            if (svg.Picture == null)
+                                return;
 
-                        var bounds = svg.Picture.CullRect;
-                        float scale = Math.Min(MaxPreviewSize / bounds.Width, MaxPreviewSize / bounds.Height);
-                        canvas.Scale(scale);
-                        canvas.Translate(-bounds.Left, -bounds.Top);
-                        canvas.DrawPicture(svg.Picture);
-                    }
-                    else
-                    {
-                        bitmap = SKBitmap.Decode(stream);
-                    }
+                            bitmap = new SKBitmap(MaxPreviewSize, MaxPreviewSize);
+                            using var canvas = new SKCanvas(bitmap);
+                            canvas.Clear(SKColors.Transparent);
 
-                    using var image = bitmap.Encode(lowercaseExtension == "jpg" ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png, 100);
-                    SetPreviewImage(image);
+                            var bounds = svg.Picture.CullRect;
+                            float scale = Math.Min(MaxPreviewSize / bounds.Width, MaxPreviewSize / bounds.Height);
+                            canvas.Scale(scale);
+                            canvas.Translate(-bounds.Left, -bounds.Top);
+                            canvas.DrawPicture(svg.Picture);
+                        }
+                        else
+                        {
+                            bitmap = SKBitmap.Decode(stream);
+                        }
 
-                    bitmap.Dispose();
-                });
-            }
+                        using var image = bitmap.Encode(lowercaseExtension == "jpg" ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png, 100);
+                        SetPreviewImage(image);
+
+                        bitmap.Dispose();
+                    });
+                }
             // Game specific extensions below
             case "ace" when GameVersion is EGame.GAME_Borderlands3:
             case "ncs" when GameVersion is EGame.GAME_Borderlands4:
@@ -451,14 +454,10 @@ public class GameFileViewModel(GameFile asset) : ViewModel
         using var ms = new MemoryStream(data.ToArray());
         ms.Position = 0;
 
-        var bitmap = new BitmapImage();
-        bitmap.BeginInit();
-        bitmap.CacheOption = BitmapCacheOption.OnLoad;
-        bitmap.StreamSource = ms;
-        bitmap.EndInit();
-        bitmap.Freeze();
-
-        Application.Current.Dispatcher.InvokeAsync(() => PreviewImage = bitmap);
+        // Bitmap reads the stream to an internal buffer during construction;
+        // it is safe to construct on a background thread and assign on the UI thread.
+        var bitmap = new Bitmap(ms);
+        Dispatcher.UIThread.Post(() => PreviewImage = bitmap);
     }
 
     private CancellationTokenSource _previewCts;
@@ -473,7 +472,8 @@ public class GameFileViewModel(GameFile asset) : ViewModel
 
         Task.Delay(100, token).ContinueWith(t =>
         {
-            if (t.IsCanceled) return;
+            if (t.IsCanceled)
+                return;
             ResolveAsync(EResolveCompute.All);
         }, TaskScheduler.FromCurrentSynchronizationContext());
     }

--- a/FModel/ViewModels/TabControlViewModel.cs
+++ b/FModel/ViewModels/TabControlViewModel.cs
@@ -6,14 +6,13 @@ using FModel.ViewModels.Commands;
 using FModel.Views.Resources.Controls;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Highlighting;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Serilog;
 using SkiaSharp;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Windows;
-using System.Windows.Media.Imaging;
 using CUE4Parse.UE4.Assets.Exports.Texture;
 using CUE4Parse_Conversion.Textures;
 using CUE4Parse.FileProvider.Objects;
@@ -41,8 +40,8 @@ public class TabImage : ViewModel
         SetImage(img);
     }
 
-    private BitmapImage _image;
-    public BitmapImage Image
+    private Bitmap _image;
+    public Bitmap Image
     {
         get => _image;
         set
@@ -84,13 +83,7 @@ public class TabImage : ViewModel
         ExportName += "." + (NoAlpha ? "jpg" : "png");
         using var data = _bmp.Encode(NoAlpha ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png, 100);
         using var stream = new MemoryStream(ImageBuffer = data.ToArray(), false);
-        var image = new BitmapImage();
-        image.BeginInit();
-        image.CacheOption = BitmapCacheOption.OnLoad;
-        image.StreamSource = stream;
-        image.EndInit();
-        image.Freeze();
-        Image = image;
+        Image = new Bitmap(stream);
     }
 
     private void SetImage(CTexture bitmap)
@@ -117,13 +110,7 @@ public class TabImage : ViewModel
         }
 
         using var stream = new MemoryStream(imageData);
-        var image = new BitmapImage();
-        image.BeginInit();
-        image.CacheOption = BitmapCacheOption.OnLoad;
-        image.StreamSource = stream;
-        image.EndInit();
-        image.Freeze();
-        Image = image;
+        Image = new Bitmap(stream);
     }
 
     private SKBitmap _bmp;

--- a/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
+++ b/FModel/Views/Resources/Controls/Mgn/Magnifier.cs
@@ -46,7 +46,7 @@ public class Magnifier : Control
 
     public static readonly StyledProperty<double> ZoomFactorProperty =
         AvaloniaProperty.Register<Magnifier, double>(nameof(ZoomFactor), defaultValue: 0.5,
-            validate: v => v >= 0);
+            validate: v => v > 0);
     public double ZoomFactor
     {
         get => GetValue(ZoomFactorProperty);

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierAdorner.cs
@@ -67,6 +67,12 @@ public class MagnifierAdorner : Canvas
         // Adorner-canvas-relative position (used for magnifier placement on the canvas).
         var pt = e.GetPosition(this);
 
+        // Before the first layout pass the canvas Bounds are zero — positions are
+        // meaningless until the adorner has been measured.  The next PointerMoved
+        // event (which fires after layout) will have correct coordinates.
+        if (Bounds.Width == 0 && Bounds.Height == 0)
+            return;
+
         if (_currentPointerPosition == pt && _magnifier.ZoomFactor == _currentZoomFactor)
             return;
 

--- a/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
+++ b/FModel/Views/Resources/Controls/Mgn/MagnifierManager.cs
@@ -78,10 +78,10 @@ public class MagnifierManager
             _element.PointerWheelChanged -= ElementOnPointerWheelChanged;
             _element.DetachedFromVisualTree -= OnElementDetached;
 
-            // Remove the adorner control from the AdornerLayer so it is not left
-            // as an invisible orphan child for the lifetime of the host window.
-            // Use the static API to match the add path in VerifyAdornerLayer.
-            AdornerLayer.SetAdornment(_element, null);
+            // Remove the adorner from the AdornerLayer's Children collection so it
+            // is not left as an invisible orphan for the lifetime of the host window.
+            if (_adorner?.Parent is AdornerLayer detachLayer)
+                detachLayer.Children.Remove(_adorner);
         }
         _adorner?.Detach();
         _adorner = null;
@@ -123,20 +123,31 @@ public class MagnifierManager
 
         // WPF Delta < 0 = scroll down = zoom out (larger viewbox); Delta > 0 = scroll up = zoom in.
         // Avalonia Delta.Y > 0 = scroll up.
+        bool zoomed = false;
         if (e.Delta.Y < 0)
         {
             var newValue = magnifier.ZoomFactor + magnifier.ZoomFactorOnMouseWheel;
             magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
+            zoomed = true;
         }
         else if (e.Delta.Y > 0)
         {
-            var newValue = magnifier.ZoomFactor >= magnifier.ZoomFactorOnMouseWheel
+            // Clamp: the property validator rejects values <= 0, so floor at
+            // ZoomFactorOnMouseWheel to stay positive after subtraction.
+            var newValue = magnifier.ZoomFactor > magnifier.ZoomFactorOnMouseWheel
                 ? magnifier.ZoomFactor - magnifier.ZoomFactorOnMouseWheel
-                : 0d;
+                : magnifier.ZoomFactorOnMouseWheel;
             magnifier.SetCurrentValue(Magnifier.ZoomFactorProperty, newValue);
+            zoomed = true;
         }
 
-        _adorner?.UpdateViewBox();
+        if (zoomed && _adorner is { IsVisible: true })
+        {
+            _adorner.UpdateViewBox();
+            // Consume the event so a parent ScrollViewer does not also scroll
+            // while the magnifier is active.
+            e.Handled = true;
+        }
     }
 
     private void ShowAdorner()
@@ -156,7 +167,10 @@ public class MagnifierManager
 
         var layer = AdornerLayer.GetAdornerLayer(_element);
         if (layer != null)
-            AdornerLayer.SetAdornment(_element, _adorner);
+        {
+            AdornerLayer.SetAdornedElement(_adorner, _element);
+            layer.Children.Add(_adorner);
+        }
     }
 
     private void HideAdorner()


### PR DESCRIPTION
## Summary

Resolves #24 — replaces `System.Windows.Media.Imaging.BitmapImage` and `System.Windows.Media.ImageSource` in the three affected ViewModels with `Avalonia.Media.Imaging.Bitmap`, enabling tab icons, asset preview thumbnails, and directory icons to render on Linux.

---

## Files Changed

### `ViewModels/TabControlViewModel.cs` (`TabImage` class)

- Removed `using System.Windows` and `using System.Windows.Media.Imaging`
- Added `using Avalonia.Media.Imaging`
- `BitmapImage _image` / `public BitmapImage Image` → `Bitmap`
- Both `SetImage` overloads (`SKBitmap` and `CTexture`): replaced the WPF `BeginInit` / `CacheOption` / `StreamSource` / `EndInit` / `Freeze` pattern with `Image = new Bitmap(stream)`. `Bitmap` reads the full stream into an internal buffer at construction; the surrounding `using MemoryStream` is safe to dispose afterward.

### `ViewModels/GameFileViewModel.cs`

- Removed `using System.Windows`, `System.Windows.Media`, `System.Windows.Media.Imaging`
- Added `using Avalonia.Media.Imaging`, `using Avalonia.Threading`
- `ImageSource _previewImage` / `public ImageSource PreviewImage` → `Bitmap`
- `SetPreviewImage(SKData)`: replaced WPF `BitmapImage` construction + `Application.Current.Dispatcher.InvokeAsync` with `new Bitmap(stream)` + `Dispatcher.UIThread.Post`. `Bitmap` is immutable and not UI-thread-affine; constructing on the background thread and posting the property assignment is correct and safe. This also resolves the one remaining `Application.Current.Dispatcher` usage that was intentionally excluded from PR #78 (it required a simultaneous image-type change).

### `ViewModels/CustomDirectoriesViewModel.cs`

- Removed `using System.Windows`, `System.Windows.Controls`, `System.Windows.Media.Imaging`
- Added `using Avalonia.Controls`, `using Avalonia.Layout`, `using Avalonia.Media.Imaging`, `using Avalonia.Platform`
- `MenuItem` / `Image` / `Separator` / `Control` → Avalonia equivalents (same class names, different namespaces; `Tag`, `Header`, `Command`, `CommandParameter`, `ItemsSource`, `StaysOpenOnClick`, `HorizontalContentAlignment`, `VerticalContentAlignment` are all present on Avalonia's `MenuItem`)
- `new BitmapImage(new Uri("/FModel;component/Resources/xxx.png", UriKind.Relative))` → `new Bitmap(AssetLoader.Open(new Uri("avares://FModel/Resources/xxx.png")))` for the four directory-icon menu items (`add_directory.png`, `go_to_directory.png`, `edit.png`, `delete.png`)