### PR TITLE
fix: replace winbrand.dll BrandingFormatString with RuntimeInformation.OSDescription

### DIFF
--- a/FModel/App.xaml.cs
+++ b/FModel/App.xaml.cs
@@ -12,7 +12,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CUE4Parse;
 using FModel.Framework;
@@ -27,11 +26,6 @@ namespace FModel;
 /// </summary>
 public partial class App : Application
 {
-    [DllImport("winbrand.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [SupportedOSPlatform("windows")]
-    private static extern string BrandingFormatString(string format);
-
     public App()
     {
         InitializeComponent();
@@ -241,18 +235,7 @@ public partial class App : Application
 
     private string GetOperatingSystemProductName()
     {
-        var productName = string.Empty;
-        if (OperatingSystem.IsWindows())
-        {
-            try
-            {
-                productName = BrandingFormatString("%WINDOWS_LONG%");
-            }
-            catch
-            {
-                // ignored
-            }
-        }
+        var productName = RuntimeInformation.OSDescription;
 
         if (string.IsNullOrEmpty(productName))
             productName = Environment.OSVersion.VersionString;


### PR DESCRIPTION
## Summary

Replace the `winbrand.dll` `BrandingFormatString` P/Invoke with the cross-platform `RuntimeInformation.OSDescription`.

## Changes

- Removed the `[DllImport("winbrand.dll")]` P/Invoke declaration and its `[DefaultDllImportSearchPaths]` / `[SupportedOSPlatform]` attributes
- Replaced the Windows-guarded `BrandingFormatString("%WINDOWS_LONG%")` call in `GetOperatingSystemProductName()` with `RuntimeInformation.OSDescription`
- Removed the now-unused `using System.Runtime.Versioning;` directive

## Behavior

| Platform | Before | After |
|----------|--------|-------|
| Windows | `"Windows 10 Pro"` (from winbrand) | `"Microsoft Windows 10.0.22631"` (from RuntimeInformation) |
| Linux | Would throw `DllNotFoundException`; fell back to `Environment.OSVersion.VersionString` | `"Linux 6.8.0-45-generic #45-Ubuntu SMP"` (from RuntimeInformation) |

The `Environment.OSVersion.VersionString` fallback is preserved for the unlikely case where `RuntimeInformation.OSDescription` returns empty.

## Verification

- `App.xaml.cs` compiles cleanly with no errors
- No other files reference `BrandingFormatString` or `winbrand.dll`

Closes #30