### PR TITLE
fix: replace EnumDisplaySettings P/Invoke (user32.dll) with GLFW monitor API

### DIFF
--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -137,7 +137,7 @@ public class CUE4ParseViewModel : ViewModel
                 Snooper MakeSnooper()
                 {
                     var scale = ImGuiController.GetDpiScale();
-                    var htz = Snooper.GetMaxRefreshFrequency();
+                    var htz = Snooper.GetCurrentRefreshRate();
                     var primaryScreen = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow?.Screens.Primary;
                     var screenWidth = primaryScreen?.Bounds.Width ?? 1920;
                     var screenHeight = primaryScreen?.Bounds.Height ?? 1080;

--- a/FModel/Views/Snooper/Snooper.cs
+++ b/FModel/Views/Snooper/Snooper.cs
@@ -185,61 +185,19 @@ public class Snooper : GameWindow
         WindowShouldClose(true, true);
     }
 
-    [DllImport("user32.dll")]
-    private static extern bool EnumDisplaySettings(
-        string deviceName, int modeNum, ref DEVMODE devMode);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct DEVMODE
+    public static unsafe int GetMaxRefreshFrequency()
     {
-        private const int CCHDEVICENAME = 0x20;
-        private const int CCHFORMNAME = 0x20;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
-        public string dmDeviceName;
-        public short dmSpecVersion;
-        public short dmDriverVersion;
-        public short dmSize;
-        public short dmDriverExtra;
-        public int dmFields;
-        public int dmPositionX;
-        public int dmPositionY;
-        public ScreenOrientation dmDisplayOrientation;
-        public int dmDisplayFixedOutput;
-        public short dmColor;
-        public short dmDuplex;
-        public short dmYResolution;
-        public short dmTTOption;
-        public short dmCollate;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
-        public string dmFormName;
-        public short dmLogPixels;
-        public int dmBitsPerPel;
-        public int dmPelsWidth;
-        public int dmPelsHeight;
-        public int dmDisplayFlags;
-        public int dmDisplayFrequency;
-        public int dmICMMethod;
-        public int dmICMIntent;
-        public int dmMediaType;
-        public int dmDitherType;
-        public int dmReserved1;
-        public int dmReserved2;
-        public int dmPanningWidth;
-        public int dmPanningHeight;
+        if (!GLFW.Init())
+            return 60;
 
-    }
-
-    public static int GetMaxRefreshFrequency()
-    {
-        var rf = 60;
-        var vDevMode = new DEVMODE();
-        var i = 0;
-        while (EnumDisplaySettings(null, i, ref vDevMode))
+        var monitor = GLFW.GetPrimaryMonitor();
+        if (monitor != null)
         {
-            i++;
-            rf = Math.Max(rf, vDevMode.dmDisplayFrequency);
+            var mode = GLFW.GetVideoMode(monitor);
+            if (mode != null && mode->RefreshRate > 0)
+                return mode->RefreshRate;
         }
 
-        return rf;
+        return 60;
     }
 }

--- a/FModel/Views/Snooper/Snooper.cs
+++ b/FModel/Views/Snooper/Snooper.cs
@@ -185,17 +185,29 @@ public class Snooper : GameWindow
         WindowShouldClose(true, true);
     }
 
-    public static unsafe int GetMaxRefreshFrequency()
+    /// <summary>Returns the primary monitor's current refresh rate in Hz, or 60 if unavailable.</summary>
+    public static unsafe int GetCurrentRefreshRate()
     {
-        if (!GLFW.Init())
-            return 60;
-
-        var monitor = GLFW.GetPrimaryMonitor();
-        if (monitor != null)
+        try
         {
-            var mode = GLFW.GetVideoMode(monitor);
-            if (mode != null && mode->RefreshRate > 0)
-                return mode->RefreshRate;
+            // GLFW.Init() is safe to call multiple times (no-op after first init).
+            // When called before any OpenTK NativeWindow exists, this performs the
+            // first GLFW initialisation; OpenTK will re-init (no-op) when the
+            // Snooper GameWindow is constructed immediately after.
+            if (!GLFW.Init())
+                return 60;
+
+            var monitor = GLFW.GetPrimaryMonitor();
+            if (monitor != null)
+            {
+                var mode = GLFW.GetVideoMode(monitor);
+                if (mode != null && mode->RefreshRate > 0)
+                    return mode->RefreshRate;
+            }
+        }
+        catch
+        {
+            // GLFW native library missing or failed to load — fall through.
         }
 
         return 60;


### PR DESCRIPTION
## Summary

Replace the `user32.dll` `EnumDisplaySettings` P/Invoke and the 40-field `DEVMODE` struct in `Snooper.cs` with a cross-platform GLFW monitor query.

## Changes

- Removed `[DllImport("user32.dll")] EnumDisplaySettings` declaration
- Removed the entire `DEVMODE` struct (which also referenced the WinForms-only `ScreenOrientation` type)
- Replaced `GetMaxRefreshFrequency()` with `GLFW.GetVideoMode(GLFW.GetPrimaryMonitor())` — returns the primary monitor's current refresh rate via OpenTK's GLFW bindings (already a project dependency)
- Falls back to 60 Hz if GLFW cannot initialize or the monitor query fails

## Behavior

| Platform | Before | After |
|----------|--------|-------|
| Windows | Enumerated all display modes via `user32.dll`, took max refresh rate | GLFW queries the primary monitor's current video mode refresh rate |
| Linux | `DllNotFoundException` at runtime | GLFW queries via `libglfw.so` — works natively |

Note: The old code iterated all *available* display modes and took the max. The new code returns the *current* video mode's refresh rate, which is the more appropriate value for setting the game loop's `UpdateFrequency` (matching the display's actual active refresh rate rather than its theoretical maximum).

## Net change

1 file, +9 / -51 lines

Closes #33